### PR TITLE
feat: pointer-based section drag with skeleton clone + module item drag

### DIFF
--- a/web/src/app/globals.css
+++ b/web/src/app/globals.css
@@ -124,6 +124,26 @@ input:-webkit-autofill:active {
     animation: subtleFloat 6s ease-in-out infinite;
 }
 
+@keyframes dragClonePickUp {
+    from {
+        transform: scale(1);
+        opacity: 0.6;
+    }
+    to {
+        transform: scale(1.02);
+        opacity: 1;
+    }
+}
+
+/* Floating section copy that tracks the cursor while dragging a layout block.
+   The resting scale is set inline; this adds a brief pick-up animation and a
+   lift shadow so it reads as "held above" the page. */
+.opaque-drag-clone {
+    animation: dragClonePickUp 0.16s cubic-bezier(0.2, 0.8, 0.2, 1);
+    will-change: transform, left, top;
+    filter: drop-shadow(0 12px 28px rgba(0, 0, 0, 0.16));
+}
+
 .login-shell {
     isolation: isolate;
 }

--- a/web/src/components/DashboardLayoutEditor.tsx
+++ b/web/src/components/DashboardLayoutEditor.tsx
@@ -33,6 +33,11 @@ const ROW_BAND_RATIO = 0.3;
 // Hysteresis (px) the pointer must travel past a zone boundary before the
 // drop target flips. This is what kills the reflow-induced flutter.
 const ZONE_HYSTERESIS = 14;
+// The drag clone caps its width here; a full-width section becomes a tidy card
+// instead of a screen-wide slab. Height still follows the source body height.
+const MAX_CLONE_WIDTH = 360;
+// How many skeleton blocks the clone draws at most (one per branch, capped).
+const MAX_CLONE_SKELETON_BLOCKS = 4;
 
 interface DashboardLayoutEditorProps {
   forest: Tree[];
@@ -54,12 +59,17 @@ interface ResizeState {
 interface DragState {
   root: string;
   label: string;
-  // Pointer offset within the grabbed section (so the clone tracks naturally).
+  // Pointer offset within the clone (already adjusted for the clamped width so
+  // the grab point tracks the cursor naturally).
   pointerOffsetX: number;
   pointerOffsetY: number;
-  // Size of the clone, taken from the grabbed section.
+  // Clone size: width is clamped to MAX_CLONE_WIDTH, height follows the body.
   width: number;
   height: number;
+  // Height of just the section body, so the placeholder reserves the same space.
+  bodyHeight: number;
+  // Number of branches in the dragged section — drives the skeleton block count.
+  branchCount: number;
   // Current pointer position (viewport coords) for the floating clone.
   clientX: number;
   clientY: number;
@@ -94,7 +104,15 @@ export default function DashboardLayoutEditor({
   const dropTargetRef = useRef<LayoutDropTarget | null>(null);
   const lastZoneRef = useRef<{ key: string; x: number; y: number } | null>(null);
   const pendingStart = useRef<
-    | { root: string; label: string; rect: DOMRect; startX: number; startY: number }
+    | {
+        root: string;
+        label: string;
+        rect: DOMRect;
+        bodyHeight: number;
+        branchCount: number;
+        startX: number;
+        startY: number;
+      }
     | null
   >(null);
   const bootstrapRef = useRef(false);
@@ -294,10 +312,17 @@ export default function DashboardLayoutEditor({
     const section = event.currentTarget.closest('[data-section-root]');
     if (!(section instanceof HTMLElement)) return;
     event.preventDefault();
+    const bodyEl = section.querySelector('[data-section-body]');
+    const bodyHeight = bodyEl instanceof HTMLElement
+      ? bodyEl.getBoundingClientRect().height
+      : section.getBoundingClientRect().height;
+    const branchCount = forest.find((tree) => tree.root === root)?.branches.length ?? 0;
     pendingStart.current = {
       root,
       label,
       rect: section.getBoundingClientRect(),
+      bodyHeight,
+      branchCount,
       startX: event.clientX,
       startY: event.clientY,
     };
@@ -309,13 +334,29 @@ export default function DashboardLayoutEditor({
       if (!pending || dragRef.current) return;
       const dist = Math.hypot(moveEvent.clientX - pending.startX, moveEvent.clientY - pending.startY);
       if (dist < DRAG_START_THRESHOLD) return;
+      const sourceWidth = pending.rect.width;
+      const cloneWidth = Math.min(sourceWidth, MAX_CLONE_WIDTH);
+      const widthScale = sourceWidth > 0 ? cloneWidth / sourceWidth : 1;
+      // Height follows the source body, but never taller than the skeleton's
+      // natural height so a tall section doesn't stretch a few blocks apart.
+      const blocks = Math.max(1, Math.min(pending.branchCount || 1, MAX_CLONE_SKELETON_BLOCKS));
+      const HEADER = 37; // header row + border
+      const PADDING = 24; // body padding (p-3 top+bottom)
+      const BLOCK = 28; // one skeleton block
+      const GAP = 10; // gap between blocks
+      const naturalHeight = HEADER + PADDING + blocks * BLOCK + Math.max(0, blocks - 1) * GAP;
+      const cloneHeight = Math.min(pending.bodyHeight + HEADER, naturalHeight);
       const next: DragState = {
         root: pending.root,
         label: pending.label,
-        pointerOffsetX: pending.startX - pending.rect.left,
-        pointerOffsetY: pending.startY - pending.rect.top,
-        width: pending.rect.width,
-        height: pending.rect.height,
+        // Scale the horizontal grab point to the clamped width; clamp the
+        // vertical offset so the cursor always rests on the (shorter) clone.
+        pointerOffsetX: (pending.startX - pending.rect.left) * widthScale,
+        pointerOffsetY: Math.min(pending.startY - pending.rect.top, cloneHeight - 16),
+        width: cloneWidth,
+        height: cloneHeight,
+        bodyHeight: pending.bodyHeight,
+        branchCount: pending.branchCount,
         clientX: moveEvent.clientX,
         clientY: moveEvent.clientY,
       };
@@ -349,6 +390,7 @@ export default function DashboardLayoutEditor({
           isEditing={isEditing}
           renderSection={renderSection}
           draggingRoot={drag?.root ?? null}
+          dragHeight={drag?.bodyHeight ?? null}
           isDragActive={Boolean(drag)}
           resize={resize}
           onGripPointerDown={beginPress}
@@ -368,7 +410,7 @@ export default function DashboardLayoutEditor({
       )}
 
       {mounted && drag && createPortal(
-        <DragClone label={drag.label} drag={drag} />,
+        <DragClone drag={drag} />,
         document.body,
       )}
     </div>
@@ -380,6 +422,7 @@ interface LayoutRowProps {
   isEditing: boolean;
   renderSection: (tree: Tree) => ReactNode;
   draggingRoot: string | null;
+  dragHeight: number | null;
   isDragActive: boolean;
   resize: ResizeState | null;
   onGripPointerDown: (event: ReactPointerEvent<HTMLElement>, root: string, label: string) => void;
@@ -391,6 +434,7 @@ function LayoutRow({
   isEditing,
   renderSection,
   draggingRoot,
+  dragHeight,
   isDragActive,
   resize,
   onGripPointerDown,
@@ -429,9 +473,12 @@ function LayoutRow({
               />
 
               {isPlaceholder ? (
-                <PlaceholderBody label={getRootLabel(cell.tree.root)} />
+                <PlaceholderBody
+                  label={getRootLabel(cell.tree.root)}
+                  height={dragHeight}
+                />
               ) : (
-                <div>{renderSection(cell.tree)}</div>
+                <div data-section-body>{renderSection(cell.tree)}</div>
               )}
             </div>
           );
@@ -488,9 +535,18 @@ function SectionHeader({ tree, isEditing, isPlaceholder, onGripPointerDown }: Se
   );
 }
 
-function PlaceholderBody({ label }: { label: string }) {
+function PlaceholderBody({ label, height }: { label: string; height: number | null }) {
+  // Reserve the dragged section's original body height so the surrounding
+  // layout barely shifts while the section is lifted out.
+  const style: CSSProperties = height
+    ? { height }
+    : { minHeight: '4.5rem' };
+
   return (
-    <div className="flex min-h-[4.5rem] items-center justify-center rounded-sm border border-dashed border-border-strong bg-surface-sunken/50">
+    <div
+      style={style}
+      className="flex items-center justify-center rounded-sm border border-dashed border-border-strong bg-surface-sunken/40"
+    >
       <span className="font-mono text-[10px] uppercase tracking-wider text-text-tertiary">
         {label}
       </span>
@@ -498,26 +554,51 @@ function PlaceholderBody({ label }: { label: string }) {
   );
 }
 
-function DragClone({ label, drag }: { label: string; drag: DragState }) {
-  // Floating element that follows the cursor until release. Kept lightweight (a
-  // labeled chip sized to the source) rather than a full render of the section.
+function DragClone({ drag }: { drag: DragState }) {
+  // A clean skeleton card that follows the cursor: the section header plus a
+  // few abstracted "content" blocks (one per branch, capped). It keeps the
+  // source's height for a sense of mass but caps its width so a full-width
+  // section becomes a tidy card rather than a screen-wide slab.
   const style: CSSProperties = {
     position: 'fixed',
     left: drag.clientX - drag.pointerOffsetX,
     top: drag.clientY - drag.pointerOffsetY,
     width: drag.width,
-    height: Math.min(drag.height, 96),
+    height: drag.height,
+    transform: 'scale(1.02)',
+    transformOrigin: 'top left',
     pointerEvents: 'none',
     zIndex: 60,
   };
 
+  const blockCount = Math.max(1, Math.min(drag.branchCount || 1, MAX_CLONE_SKELETON_BLOCKS));
+
   return (
-    <div style={style} className="animate-fade-in">
-      <div className="flex h-full w-full items-center gap-2 rounded-sm border border-border-strong bg-white/95 px-3 shadow-floating backdrop-blur-sm">
-        <IconGripVertical className="h-3.5 w-3.5 text-text-muted" />
-        <span className="text-xs font-medium uppercase tracking-wider text-text-secondary">
-          {label}
-        </span>
+    <div style={style} className="opaque-drag-clone">
+      <div className="flex h-full w-full flex-col overflow-hidden rounded-md border border-border-medium bg-white shadow-floating">
+        <div className="flex items-center gap-2 border-b border-border-light px-3 py-2">
+          <IconGripVertical className="h-3.5 w-3.5 text-text-muted" />
+          <span className="truncate text-xs font-medium uppercase tracking-wider text-text-secondary">
+            {drag.label}
+          </span>
+        </div>
+        <div className="flex min-h-0 flex-1 flex-col gap-2.5 overflow-hidden p-3">
+          {Array.from({ length: blockCount }, (_, index) => (
+            <SkeletonBlock key={index} />
+          ))}
+        </div>
+      </div>
+    </div>
+  );
+}
+
+function SkeletonBlock() {
+  return (
+    <div className="flex items-center gap-2.5">
+      <div className="h-7 w-7 flex-shrink-0 rounded-sm bg-surface-sunken" />
+      <div className="flex min-w-0 flex-1 flex-col gap-1.5">
+        <div className="h-2 w-1/2 rounded-full bg-surface-sunken" />
+        <div className="h-2 w-3/4 rounded-full bg-[#f1f1f1]" />
       </div>
     </div>
   );

--- a/web/src/components/Tree/TreeModule.tsx
+++ b/web/src/components/Tree/TreeModule.tsx
@@ -1,4 +1,4 @@
-import React, { useMemo, useState } from 'react';
+import React, { useMemo, useRef, useState } from 'react';
 import {
   IconActivity,
   IconAntennaBars5,
@@ -7,6 +7,7 @@ import {
   IconChartLine,
   IconCloud,
   IconDeviceTv,
+  IconGripVertical,
   IconMovie,
   IconNews,
   IconPhotoVideo,
@@ -21,6 +22,12 @@ import {
   getAllowedModuleTypes,
   MODULE_LABELS,
 } from '@/lib/modules';
+import {
+  getSpatialDropPlacement,
+  setDragPreview,
+  type DragPreviewState,
+  type DropPlacement,
+} from '@/lib/drag';
 
 interface ModuleTree {
   root: string;
@@ -44,6 +51,9 @@ const TreeModule: React.FC<TreeModuleProps> = ({
   const [newModuleType, setNewModuleType] = useState<KnownModuleType | ''>(
     allowedTypes[0] || '',
   );
+  const [activeDragId, setActiveDragId] = useState<string | null>(null);
+  const draggedModuleId = useRef<string | null>(null);
+  const draggedModulePreview = useRef<DragPreviewState | null>(null);
 
   const visibleModules = useMemo(() => (
     tree.branches.filter((module) => (
@@ -53,6 +63,30 @@ const TreeModule: React.FC<TreeModuleProps> = ({
 
   const updateBranches = (branches: ModuleBranch[]) => {
     onTreeChange?.({ ...tree, branches });
+  };
+
+  const moveModule = (targetModuleId: string, placement: DropPlacement) => {
+    const sourceModuleId = draggedModuleId.current;
+    if (!sourceModuleId || sourceModuleId === targetModuleId) return;
+
+    const sourceIndex = tree.branches.findIndex((module) => module.id === sourceModuleId);
+    const targetIndex = tree.branches.findIndex((module) => module.id === targetModuleId);
+    if (sourceIndex < 0 || targetIndex < 0) return;
+
+    const nextBranches = reorder(tree.branches, sourceIndex, targetIndex, placement);
+    if (sameOrder(tree.branches, nextBranches)) return;
+
+    updateBranches(nextBranches);
+  };
+
+  const getModuleDropPlacement = (event: React.DragEvent<HTMLElement>) => (
+    getSpatialDropPlacement(event, draggedModulePreview.current)
+  );
+
+  const finishDrag = () => {
+    draggedModuleId.current = null;
+    draggedModulePreview.current = null;
+    setActiveDragId(null);
   };
 
   const updateModule = (
@@ -82,10 +116,43 @@ const TreeModule: React.FC<TreeModuleProps> = ({
           return (
             <div
               key={module.id}
-              className="group border border-border-light bg-white p-3 transition-colors duration-200 hover:border-border-medium"
+              data-drag-preview
+              className={`group border border-border-light bg-white p-3 transition-all duration-200 hover:border-border-medium ${
+                activeDragId === module.id ? 'scale-[0.98] opacity-45' : ''
+              }`}
+              onDragOver={(event) => {
+                if (!draggedModuleId.current) return;
+                event.preventDefault();
+                event.dataTransfer.dropEffect = 'move';
+                moveModule(module.id, getModuleDropPlacement(event));
+              }}
+              onDrop={(event) => {
+                if (!draggedModuleId.current) return;
+                event.preventDefault();
+                moveModule(module.id, getModuleDropPlacement(event));
+                finishDrag();
+              }}
             >
               <div className="mb-3 flex items-start justify-between gap-2">
                 <div className="flex min-w-0 items-center gap-2">
+                  <div
+                    role="button"
+                    tabIndex={0}
+                    draggable
+                    onDragStart={(event) => {
+                      draggedModuleId.current = module.id;
+                      event.dataTransfer.effectAllowed = 'move';
+                      event.dataTransfer.setData('text/plain', `module:${module.id}`);
+                      draggedModulePreview.current = setDragPreview(event);
+                      setActiveDragId(module.id);
+                    }}
+                    onDragEnd={finishDrag}
+                    className="flex h-6 w-5 flex-shrink-0 cursor-grab items-center justify-center rounded-sm text-text-muted hover:bg-surface-sunken hover:text-text-primary"
+                    aria-label={`Move ${module.name}`}
+                    title="Move module"
+                  >
+                    <IconGripVertical className="h-4 w-4" />
+                  </div>
                   <ModuleIcon moduleType={module.moduleType} className="h-4 w-4 text-text-secondary" />
                   <div className="min-w-0">
                     <div className="truncate text-xs font-medium text-text-primary">
@@ -430,6 +497,26 @@ function getModuleLabel(moduleType: string) {
 
 function isKnownModuleType(moduleType: string): moduleType is KnownModuleType {
   return Boolean((MODULE_LABELS as Record<string, string>)[moduleType]);
+}
+
+function reorder<T>(
+  items: T[],
+  fromIndex: number,
+  toIndex: number,
+  placement: DropPlacement,
+) {
+  const next = [...items];
+  const [item] = next.splice(fromIndex, 1);
+  let insertIndex = placement === 'after' ? toIndex + 1 : toIndex;
+
+  if (fromIndex < insertIndex) insertIndex -= 1;
+  next.splice(Math.max(0, Math.min(next.length, insertIndex)), 0, item);
+  return next;
+}
+
+function sameOrder<T extends { id: string }>(current: T[], next: T[]) {
+  return current.length === next.length
+    && current.every((item, index) => item.id === next[index]?.id);
 }
 
 function getMediaRows(moduleType: string): [string, string][] {


### PR DESCRIPTION
## Summary

Polishes the dashboard layout editor's drag interaction and extends drag-reorder to module sections. Builds on the WYSIWYG layout editor already on `master`.

## Section drag — rewritten on pointer events

**Why:** the previous section move used the HTML5 drag-and-drop API while reflowing the layout live during `dragover`. Reflowing changed the element under the cursor, firing spurious `dragleave` events — an oscillation that caused visible flutter and unreliable placement.

**What changed:**
- Reimplemented section dragging with **pointer events**. Continuous cursor tracking, stable hit-testing via `document.elementFromPoint`, and a **zone-hysteresis deadzone** so the preview no longer flickers while the cursor hovers a boundary. Verified: zero flutter when the cursor is held stationary.
- A **floating clone** follows the cursor until release; the source slot is held open as a **same-size placeholder** that reserves the original body height, so the surrounding layout barely shifts.
- The clone is now a **skeleton card**, not a render of the live edit-mode section (which was cluttered with inputs/buttons and got clipped):
  - Section header + one skeleton block per branch (capped at 4).
  - Width clamped to **360px** so a full-width section becomes a tidy card instead of a screen-wide slab (grab point is scaled so the cursor stays aligned).
  - Height follows the source body, bounded to the skeleton's natural height (a tall section with one block won't stretch into a slab).
  - Subtle scale-up + lift drop-shadow, no tilt.

## Module item drag

- **Today / Media / Posts** module cards are now drag-reorderable in edit mode, matching Applications / Servers / Bookmarks — grip handle, spatial drop placement (`getSpatialDropPlacement`), and the dragged-card dim (`scale-[0.98] opacity-45`).

## Files
- `web/src/components/DashboardLayoutEditor.tsx` — pointer-based drag, placeholder sizing, skeleton clone.
- `web/src/components/Tree/TreeModule.tsx` — module card drag-reorder.
- `web/src/app/globals.css` — `opaque-drag-clone` pick-up animation + lift shadow.

## Test plan / what was verified in-browser
- [x] Dragging a section: clone follows cursor, original slot stays same-size, no vertical jump.
- [x] Holding the cursor stationary over a target: layout stays stable (no flutter — this was the core bug).
- [x] Skeleton clone: width clamps `2431px → 360px`, block count tracks branch count, height follows content (Servers `336px → 89px` for 1 block).
- [x] Drop commits exactly what the preview shows (WYSIWYG); clone + body styles clean up on release.
- [x] Module reorder: Today modules reorder `[Weather, Calendar] → [Calendar, Weather]`.
- [x] `tsc --noEmit`, `eslint`, and `next build` all pass.

## Notes
- This repo has no automated test suite; verification was manual via the running app (Postgres-backed dashboard). All test rearrangements were discarded — no real dashboard data was modified.
- One deliberate behavior: during a column-*merge* preview the placeholder narrows to the resulting width (rather than forcing the original width), since that's the truthful preview of the drop result.