### PR TITLE
feat(dashboard): loading skeletons, instant posts tabs, header tabs, layout polish

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,36 @@
+# OPAQUE
+
+A quiet, self-hosted dashboard (bookmarks / applications / servers / today / media / posts).
+Next.js 15 App Router + Tailwind, Postgres via Drizzle, all dashboard UI client-rendered.
+
+## Design system — read before any UI work
+
+The design philosophy is **Quiet Instrumentality** and it is codified in
+[web/DESIGN_SPEC.md](web/DESIGN_SPEC.md). That file is the source of truth for every visual and
+interaction decision. Non-negotiables, summarized:
+
+- Serif (`font-serif`) for titles only; mono for data; sans for prose. Tabular numerals globally.
+- One accent (moss `accent-green`) meaning *alive/active*; errors use muted rust `accent-red`
+  (never `red-500`); warnings use `accent-amber` (never `amber-500`); no new `accent-blue` usage.
+- Motion: 180ms / one easing — the Tailwind defaults. No explicit `duration-*` without a reason.
+  Motion only on state change. Loading = structure-matched skeletons, never spinners.
+- Hover only on interactive elements, following the four-pattern grammar in the spec
+  (row lift / card border lift / icon button / text link).
+- Focus: global 1px ink `:focus-visible` outline. Keyboard reachability is required.
+- Voice: short, calm, slightly human ("Nothing new today."); relative time for freshness.
+- WYSIWYG: edit mode never reshapes view mode.
+
+When a new UI pattern is genuinely needed, add it to `web/DESIGN_SPEC.md` in the same PR.
+
+## Working conventions
+
+- App code lives in `web/`. Run checks from `web/`: `npx tsc --noEmit`, `npm run lint`,
+  `npm run build`.
+- Branch from `master` per feature; PRs to `master`. Conventional commit messages.
+- The dashboard layout model: `Tree.layout = { rowId, rowIndex, colIndex, widthPct }`;
+  pure layout ops in `web/src/lib/dashboardLayout.ts`.
+- Module data flows: `web/src/lib/moduleProviders.ts` (server fetch) →
+  `/api/modules/data` → `useModuleData` (client cache + silent refresh) → widgets in
+  `web/src/components/Tree/TreeModule.tsx`.
+- Never commit real service credentials or dashboard data; verification against the live
+  dashboard must discard draft changes.

--- a/web/DESIGN_SPEC.md
+++ b/web/DESIGN_SPEC.md
@@ -1,49 +1,93 @@
-# Design Style Description
+# OPAQUE Design Spec — Quiet Instrumentality
 
-Wabi-Sabi Minimalist Brutalism
+> 安静的工具主义。这份文档是所有 UI 决策的最终依据；新代码与这里冲突时，改代码。
 
-This bookmark navigation interface embodies a unique fusion of three distinct design philosophies, Typography-driven, creating a harmonious yet purposeful aesthetic:
+## The idea
 
-## **Wabi-Sabi Foundation**
+OPAQUE reads like a well-set technical almanac: high information density delivered in a low voice.
+Editorial minimalism meets wabi-sabi — serif carries the human voice, monospace carries the honest
+numbers, whitespace carries the breathing room. **Restraint itself is the identity: others add
+effects; we don't.**
 
-The design embraces the Japanese philosophy of finding beauty in imperfection and impermanence. This is expressed through:
+Three lineages, one temperament:
 
-- **Soft, natural color palette**: Gradient backgrounds transitioning from stone-50 to warm amber tones
-- **Organic spacing**: Generous whitespace that breathes naturally rather than following rigid mathematical grids
-- **Subtle imperfections**: Gentle backdrop blur effects and translucent overlays that create depth without harsh boundaries
-- **Natural materials inspiration**: Color choices that evoke paper, stone, and warm earth tones
+- **Wabi-sabi** — paper-like surfaces, hairline rules, asymmetry tolerated, time made visible
+  ("2 days ago" matters more than a spinner).
+- **Editorial minimalism** — Goudy serif titles set like book headings; content reads in columns;
+  typography is the layout.
+- **Quiet brutalism** — sharp 2px corners, honest borders, no decoration that isn't information.
 
-## **Minimalist Principles**
+## Hard rules
 
-The interface strips away all non-essential elements, focusing purely on function:
+These are enforceable review criteria, not vibes.
 
-- **Essential typography**: Small, clean text (text-sm, text-xs) with purposeful hierarchy
-- **Reduced visual noise**: No decorative elements that don't serve a functional purpose
-- **Clean information architecture**: Clear categorization with functional count badges
-- **Purposeful interactions**: Every element serves a specific user need
+### Type
 
-## **Brutalist Accents**
+- `font-serif` (Sorts Mill Goudy, 400) — **titles only**: welcome line, section titles, panel/module
+  titles, group headers. Never for body, buttons, labels, or data.
+- `font-body` (system sans) — everything that is prose or UI copy.
+- `font-mono` — all data: numbers, timestamps, urls, types, meta lines, status words.
+- Numerals never jitter: `font-variant-numeric: tabular-nums` is set globally on `body`.
+- Labels above data use `text-[10px] uppercase tracking-wider text-text-tertiary`.
 
-Strategic brutalist/Neo-Brutalism elements add structure and intentionality:
+### Color
 
-- **Sharp geometric borders**
-- Responsive grids that maintain order across screen sizes
-- **Functional typography**: Uppercase labels and consistent font weights that prioritize readability
-- **Asymmetrical balance**: Left-aligned content that creates visual tension while remaining readable
+- Paper surfaces: `background` `#fafafa→#fff`, cards are `bg-white` with `border-border-light`.
+- **One accent: `accent-green` (#7E846B, moss).** It means *alive / active / current* — live status
+  dots, playback, active drop targets, hover accents. Never decorative.
+- Errors and destructive hovers use the muted rust `accent-red` (#A76767) family. **Never
+  `red-500`** — saturated alarm red is off-voice.
+- Warnings (e.g. load thresholds) use muted ochre `accent-amber`. Never `amber-500`.
+- `accent-blue` is legacy; do not introduce new uses on the dashboard.
 
-## **User Experience Philosophy**
+### Motion
 
-The design prioritizes **mindful interaction** over flashy aesthetics:
+- One budget: `180ms` `cubic-bezier(0.2, 0.6, 0.2, 1)` — these are the Tailwind defaults
+  (`transition-*` with no explicit duration/easing). Do not write `duration-150`/`duration-200`
+  unless there is a measured reason.
+- Motion only on state change (hover, active, enter, drag). Nothing animates for decoration.
+- Loading is skeletons that match the real content structure — never spinners, never layout shift.
 
-- **Keyboard-first navigation**
-- **Progressive disclosure**
-- **Contextual feedback**: Subtle hover states and transitions that guide without overwhelming
-- **Accessible hierarchy**: Clear visual relationships between categories, bookmarks, and actions
+### Hover — the single grammar
 
-## 🔧 **Technical Aesthetic**
+Hover exists **only on interactive elements**, and means exactly one of four things:
 
-Perfect for the target audience of designers, developers, and digital artists:
+1. **Row / list item** (links in lists: posts, bookmark leaves, app leaves) — soft surface lift
+   `hover:bg-surface-sunken/70` on a padded `-mx-2 px-2 rounded-sm` row; title darkens; the
+   accent-green hairline may appear (left rule or underline).
+2. **Card / panel** — border lift only: `border-border-light → border-border-medium`, optional
+   `bg-[#fcfcfc]`. No shadows (shadows are reserved for *lifted* drag clones and popovers).
+3. **Icon / utility button** — `text-text-muted → text-text-primary` plus `hover:bg-surface-sunken`
+   (`.opaque-icon-button` pattern). Destructive variants darken to `accent-red-dark`.
+4. **Text link / tab** — color darkens toward ink; hairline underline appears or strengthens.
 
-This style creates a **calm, focused environment** that encourages productivity while maintaining visual interest through subtle contrasts and thoughtful spacing. It's neither sterile nor overwhelming—instead, it feels like a well-crafted tool that gets out of the way while providing exactly what's needed.
+Non-interactive things (section titles, labels, data rows that aren't links) never react to hover.
 
-The result is a design that feels both **timeless and contemporary**, honoring traditional Japanese aesthetics while embracing modern digital functionality and the honest, uncompromising spirit of brutalist design.
+### Focus
+
+- `:focus-visible` shows a 1px ink outline with 2px offset (defined globally). Never blue rings,
+  never glows. Everything clickable must be reachable and visibly focused by keyboard.
+
+### Voice
+
+- UI copy is short, lowercase-calm, and a little human. Empty states get one quiet line
+  ("Nothing new today.") — never exclamation marks, never robotic ("No data available").
+- Time is shown relatively ("2 days ago") wherever freshness is the point.
+
+### Structure
+
+- Section title sits flush-left with its content (no indents between title and body).
+- Hairline (`border-light`, 1px) is the only divider. Depth comes from spacing, not elevation.
+- Radius is `rounded-sm` (2px) for almost everything; `rounded-full` only for status dots and pills.
+- WYSIWYG: edit mode must not reshape view mode. Nothing appears in edit mode that occupies layout
+  space the view mode doesn't have (edit affordances live in headers, overlays, or handles).
+
+## Litmus tests
+
+Before shipping UI, ask:
+
+1. Did I add anything that is decoration rather than information? Remove it.
+2. Does the new state (hover/loading/empty/error) follow the four-hover grammar, skeleton rule, and
+   quiet voice? If it needed a new pattern, the pattern belongs in this file first.
+3. Would this screen still feel calm printed in a book? (Serif titles, hairlines, mono data —
+   if it looks like a dashboard SaaS ad, it's wrong.)

--- a/web/src/app/globals.css
+++ b/web/src/app/globals.css
@@ -13,11 +13,15 @@
 
     body {
         @apply min-h-screen bg-[#fafafa] font-body text-text-primary;
+        /* Numerals never jitter (see DESIGN_SPEC.md — Type). */
+        font-variant-numeric: tabular-nums;
     }
-    
-    /* Linear-inspired focus styles */
+
+    /* Quiet focus: a thin ink outline, visible everywhere, never a glow. */
     *:focus-visible {
-        @apply outline-none ring-2 ring-accent-blue ring-opacity-50;
+        outline: 1px solid theme('colors.ink.700');
+        outline-offset: 2px;
+        @apply ring-0;
     }
 }
 
@@ -142,6 +146,22 @@ input:-webkit-autofill:active {
     animation: dragClonePickUp 0.16s cubic-bezier(0.2, 0.8, 0.2, 1);
     will-change: transform, left, top;
     filter: drop-shadow(0 12px 28px rgba(0, 0, 0, 0.16));
+}
+
+@keyframes posterZoomIn {
+    from {
+        opacity: 0;
+        transform: scale(0.98);
+    }
+    to {
+        opacity: 1;
+        transform: scale(1);
+    }
+}
+
+/* In-module poster lightbox enter; matches the 180ms motion budget. */
+.animate-poster-zoom {
+    animation: posterZoomIn 180ms cubic-bezier(0.2, 0.6, 0.2, 1) both;
 }
 
 .login-shell {
@@ -542,7 +562,8 @@ input:-webkit-autofill:active {
     .login-bookmark-text,
     .login-bookmark-caret,
     .login-caret,
-    .login-pulse {
+    .login-pulse,
+    .animate-poster-zoom {
         animation: none !important;
     }
 }
@@ -598,7 +619,7 @@ input:-webkit-autofill:active {
    =============================================== */
 @layer components {
     .linear-card {
-        @apply bg-surface-elevated border border-border-light rounded shadow-subtle transition-all duration-200;
+        @apply bg-surface-elevated border border-border-light rounded shadow-subtle transition-all;
     }
     
     .linear-divider {
@@ -606,7 +627,7 @@ input:-webkit-autofill:active {
     }
 
     .opaque-card {
-        @apply rounded-sm border border-border-light bg-white shadow-none transition-colors duration-200;
+        @apply rounded-sm border border-border-light bg-white shadow-none transition-colors;
     }
 
     .opaque-card:hover {
@@ -615,12 +636,12 @@ input:-webkit-autofill:active {
 
     .opaque-button {
         height: var(--opaque-header-control-size);
-        @apply inline-flex items-center justify-center gap-1 rounded-sm border border-border-light bg-white px-2 text-[11px] font-medium text-text-secondary transition-colors duration-200 hover:border-border-medium hover:bg-surface-sunken hover:text-text-primary disabled:cursor-not-allowed disabled:opacity-45;
+        @apply inline-flex items-center justify-center gap-1 rounded-sm border border-border-light bg-white px-2 text-[11px] font-medium text-text-secondary transition-colors hover:border-border-medium hover:bg-surface-sunken hover:text-text-primary disabled:cursor-not-allowed disabled:opacity-45;
     }
 
     .opaque-button-primary {
         height: var(--opaque-header-control-size);
-        @apply inline-flex items-center justify-center gap-1 rounded-sm border border-text-primary bg-text-primary px-2 text-[11px] font-medium text-white transition-colors duration-200 hover:bg-ink-800 disabled:cursor-not-allowed disabled:border-border-medium disabled:bg-surface-sunken disabled:text-text-muted;
+        @apply inline-flex items-center justify-center gap-1 rounded-sm border border-text-primary bg-text-primary px-2 text-[11px] font-medium text-white transition-colors hover:bg-ink-800 disabled:cursor-not-allowed disabled:border-border-medium disabled:bg-surface-sunken disabled:text-text-muted;
     }
 
     .opaque-button svg,
@@ -630,17 +651,17 @@ input:-webkit-autofill:active {
     }
 
     .opaque-icon-button {
-        @apply inline-flex h-7 w-7 items-center justify-center rounded-sm border border-transparent text-text-muted transition-colors duration-200 hover:border-border-light hover:bg-surface-sunken hover:text-text-primary;
+        @apply inline-flex h-7 w-7 items-center justify-center rounded-sm border border-transparent text-text-muted transition-colors hover:border-border-light hover:bg-surface-sunken hover:text-text-primary;
     }
 
     .opaque-input {
-        @apply h-8 rounded-sm border border-border-light bg-white px-2 text-xs text-text-primary transition-colors duration-200 placeholder:text-text-muted focus:border-border-strong focus:ring-0;
+        @apply h-8 rounded-sm border border-border-light bg-white px-2 text-xs text-text-primary transition-colors placeholder:text-text-muted focus:border-border-strong focus:ring-0;
     }
 
     .opaque-toolbar-icon {
         width: var(--opaque-header-control-size);
         height: var(--opaque-header-control-size);
-        @apply inline-flex items-center justify-center rounded-sm border border-border-light bg-white text-text-muted transition-colors duration-200 hover:border-border-medium hover:bg-surface-sunken hover:text-text-primary;
+        @apply inline-flex items-center justify-center rounded-sm border border-border-light bg-white text-text-muted transition-colors hover:border-border-medium hover:bg-surface-sunken hover:text-text-primary;
     }
 
     .opaque-toolbar-icon svg {
@@ -662,7 +683,7 @@ input:-webkit-autofill:active {
     .opaque-toolbar-avatar {
         width: var(--opaque-header-control-size);
         height: var(--opaque-header-control-size);
-        @apply flex items-center justify-center rounded-full border border-transparent bg-surface-sunken text-[11px] font-medium text-text-primary transition-colors duration-200 hover:bg-[#ededed];
+        @apply flex items-center justify-center rounded-full border border-transparent bg-surface-sunken text-[11px] font-medium text-text-primary transition-colors hover:bg-[#ededed];
     }
 
     .opaque-menu-popover {

--- a/web/src/app/page.tsx
+++ b/web/src/app/page.tsx
@@ -10,6 +10,8 @@ import Header from '@/components/Header'
 import Footer from '@/components/Footer'
 import DashboardLayoutEditor from '@/components/DashboardLayoutEditor'
 import DashboardOnboarding, { OnboardingDraft } from '@/components/DashboardOnboarding'
+import DashboardSkeleton, { saveLayoutSnapshot } from '@/components/DashboardSkeleton'
+import { getLayoutRows } from '@/lib/dashboardLayout'
 import { cloneDashboard, normalizeDashboard } from '@/lib/dashboard'
 import { Branch, Dashboard, ModuleBranch, ServerStats, Tree } from '@/lib/types'
 import {
@@ -120,6 +122,17 @@ export default function HomePage() {
   const displayName = activeDashboard?.name || activeDashboard?.username || activeDashboard?.email
   const isDashboardEmpty = visibleDashboard?.forest.every((tree) => tree.branches.length === 0) ?? false
 
+  // Remember the layout's shape so the next visit's loading skeleton can
+  // mirror the user's real structure instead of a generic frame.
+  useEffect(() => {
+    if (!dashboard) return
+    const rows = getLayoutRows(materializeImplicitLayout(dashboard.forest, false))
+    saveLayoutSnapshot(rows.map((row) => ({
+      roots: row.cells.map((cell) => String(cell.tree.root)),
+      widths: row.cells.map((cell) => cell.widthPct),
+    })))
+  }, [dashboard])
+
   const layoutForest = useMemo(() => (
     visibleDashboard ? materializeImplicitLayout(visibleDashboard.forest, isEditing) : []
   ), [visibleDashboard, isEditing])
@@ -214,13 +227,8 @@ export default function HomePage() {
       <div className="flex min-h-screen flex-col">
         <Header />
         <div className="relative flex-1 overflow-x-hidden bg-background">
-          <div className="relative z-10 flex min-h-full items-center justify-center">
-            <div className="space-y-4 text-center">
-              <div className="mx-auto h-0.5 w-8 animate-pulse bg-ink-400"></div>
-              <div className="animate-fade-in text-sm font-light tracking-wide text-text-tertiary">
-                Loading dashboard...
-              </div>
-            </div>
+          <div className="relative z-10">
+            <DashboardSkeleton />
           </div>
         </div>
       </div>
@@ -297,9 +305,10 @@ export default function HomePage() {
           <div id="dashboard" className="relative flex min-h-full flex-col py-16">
             <div className="mx-4 animate-fade-in md:mx-8">
               <div className="h-0.5 w-6 bg-ink-300"></div>
-              <div className="mt-3 font-serif text-2xl leading-none text-text-primary">
-                Welcome{displayName ? `, ${displayName}` : ''}
-              </div>
+              <p className="mt-2.5 font-serif text-sm leading-none text-text-secondary">
+                {timeGreeting()}{displayName ? `, ${displayName}` : ''}
+                <span className="text-text-muted"> — {todayLabel()}</span>
+              </p>
             </div>
 
             {!isEditing && isDashboardEmpty ? (
@@ -476,6 +485,22 @@ function hasRenderableTree(tree: Tree) {
   }
 
   return true
+}
+
+function timeGreeting() {
+  const hour = new Date().getHours()
+  if (hour < 5) return 'Good night'
+  if (hour < 12) return 'Good morning'
+  if (hour < 18) return 'Good afternoon'
+  return 'Good evening'
+}
+
+function todayLabel() {
+  return new Intl.DateTimeFormat(undefined, {
+    weekday: 'long',
+    month: 'long',
+    day: 'numeric',
+  }).format(new Date())
 }
 
 function newId() {

--- a/web/src/app/page.tsx
+++ b/web/src/app/page.tsx
@@ -36,6 +36,13 @@ export default function HomePage() {
   const [isEditing, setIsEditing] = useState(false)
   const [isDirty, setIsDirty] = useState(false)
   const [isSaving, setIsSaving] = useState(false)
+  // True only once /api/dashboard/get confirms the current session. Dashboard
+  // *content* is never painted before this — only the structure-matched
+  // skeleton (from a non-sensitive layout snapshot) shows while we wait — so a
+  // prior user's bookmarks/apps/servers can't leak on a shared browser, and
+  // there is no unverified copy that could be edited and saved over newer
+  // server state.
+  const [isVerified, setIsVerified] = useState(false)
   const router = useRouter()
 
   useEffect(() => {
@@ -55,6 +62,7 @@ export default function HomePage() {
           const normalized = normalizeDashboard(data.dashboard)
           setDashboard(normalized)
           setDraftDashboard(cloneDashboard(normalized))
+          setIsVerified(true)
         } else {
           setError('Failed to load dashboard')
         }
@@ -138,7 +146,9 @@ export default function HomePage() {
   ), [visibleDashboard, isEditing])
 
   const startEditing = () => {
-    if (!dashboard) return
+    // Editing is only safe once the server copy is confirmed: editing an
+    // unverified cached paint risks saving stale data over newer server state.
+    if (!dashboard || !isVerified) return
     setDraftDashboard(cloneDashboard(dashboard))
     setIsEditing(true)
     setIsDirty(false)
@@ -155,7 +165,9 @@ export default function HomePage() {
   }
 
   const saveDashboard = async () => {
-    if (!draftDashboard || !isDirty) return
+    // `isVerified` is the invariant that makes saving safe — never write a
+    // draft derived from an unverified cached paint back to the server.
+    if (!draftDashboard || !isDirty || !isVerified) return
 
     setIsSaving(true)
     setSaveError('')
@@ -242,7 +254,7 @@ export default function HomePage() {
         <div className="relative flex-1 overflow-x-hidden bg-background">
           <div className="relative z-10 flex min-h-full items-center justify-center">
             <div className="space-y-6 text-center">
-              <div className="mx-auto h-0.5 w-12 bg-red-400"></div>
+              <div className="mx-auto h-0.5 w-12 bg-accent-red"></div>
               <div className="space-y-2">
                 <div className="text-sm font-medium text-text-primary">
                   Unable to connect
@@ -295,6 +307,7 @@ export default function HomePage() {
         isEditing={isEditing}
         isDirty={isDirty}
         isSaving={isSaving}
+        canEdit={isVerified}
         saveError={saveError}
         onEdit={startEditing}
         onReset={resetEditing}

--- a/web/src/components/DashboardLayoutEditor.tsx
+++ b/web/src/components/DashboardLayoutEditor.tsx
@@ -572,7 +572,7 @@ function LayoutRow({
     >
       {newRowEdge && <NewRowIndicator edge={newRowEdge} />}
       <div
-        className="grid items-start transition-[grid-template-columns] duration-200 ease-out"
+        className="grid items-start transition-[grid-template-columns]"
         style={{ gridTemplateColumns, columnGap: 'var(--row-gap)', rowGap: 'var(--row-gap)' } as CSSProperties}
       >
         {row.cells.map((cell, colIndex) => {
@@ -635,12 +635,12 @@ interface SectionHeaderProps {
 function SectionHeader({ tree, isEditing, isPlaceholder, onGripPointerDown }: SectionHeaderProps) {
   const label = getRootLabel(tree.root);
   return (
-    <div className={`mb-3 flex items-center gap-3 transition-opacity duration-150 ${isPlaceholder ? 'opacity-30' : ''}`}>
+    <div className={`mb-3 flex items-center gap-3 transition-opacity ${isPlaceholder ? 'opacity-30' : ''}`}>
       {isEditing && (
         <button
           type="button"
           onPointerDown={(event) => onGripPointerDown(event, tree.root, label)}
-          className="inline-flex h-5 w-5 cursor-grab touch-none items-center justify-center text-text-muted transition-colors duration-150 hover:text-text-primary active:cursor-grabbing"
+          className="inline-flex h-5 w-5 cursor-grab touch-none items-center justify-center text-text-muted transition-colors hover:text-text-primary active:cursor-grabbing"
           aria-label={`Drag ${label} section`}
           title="Drag to rearrange"
         >
@@ -750,7 +750,7 @@ function ResizeGutter({ column, isActive, hintText, onPointerDown }: ResizeGutte
       >
         {/* Persistent faint seam line (edit mode), stronger on hover / active. */}
         <div
-          className={`absolute top-0 bottom-0 left-1/2 -translate-x-1/2 w-px transition-colors duration-150 ${
+          className={`absolute top-0 bottom-0 left-1/2 -translate-x-1/2 w-px transition-colors ${
             isActive
               ? 'bg-text-primary'
               : 'bg-border-medium group-hover/gutter:bg-text-secondary'
@@ -758,7 +758,7 @@ function ResizeGutter({ column, isActive, hintText, onPointerDown }: ResizeGutte
         />
         {/* Grip pill. Faint at rest, solid on hover / active. */}
         <div
-          className={`absolute top-1/2 left-1/2 flex h-6 w-2.5 -translate-x-1/2 -translate-y-1/2 items-center justify-center rounded-full border bg-white transition-all duration-150 ${
+          className={`absolute top-1/2 left-1/2 flex h-6 w-2.5 -translate-x-1/2 -translate-y-1/2 items-center justify-center rounded-full border bg-white transition-all ${
             isActive
               ? 'border-text-primary opacity-100'
               : 'border-border-medium opacity-60 group-hover/gutter:border-text-secondary group-hover/gutter:opacity-100'
@@ -799,7 +799,7 @@ function UnassignedTray({
   return (
     <div
       data-unassigned-tray
-      className={`mt-2 border-t pt-4 transition-colors duration-150 ${isHover ? 'border-text-primary' : 'border-border-light'}`}
+      className={`mt-2 border-t pt-4 transition-colors ${isHover ? 'border-text-primary' : 'border-border-light'}`}
     >
       <div className="flex flex-wrap items-center gap-2">
         <span className="text-[10px] uppercase tracking-wider text-text-tertiary">
@@ -820,7 +820,7 @@ function UnassignedTray({
                 data-col-index={0}
                 onPointerDown={(event) => onGripPointerDown(event, tree.root, label)}
                 onClick={() => onForestChange(assignTreeToNewRow(forest, tree.root))}
-                className={`inline-flex cursor-grab touch-none items-center gap-1.5 border border-border-light bg-white px-2 py-1 text-[11px] text-text-secondary transition-colors duration-150 hover:border-border-medium hover:text-text-primary active:cursor-grabbing ${draggingRoot === tree.root ? 'opacity-40' : ''}`}
+                className={`inline-flex cursor-grab touch-none items-center gap-1.5 border border-border-light bg-white px-2 py-1 text-[11px] text-text-secondary transition-colors hover:border-border-medium hover:text-text-primary active:cursor-grabbing ${draggingRoot === tree.root ? 'opacity-40' : ''}`}
                 title="Drag onto the dashboard, or click to add a new row"
               >
                 <IconGripVertical className="h-3 w-3 text-text-muted" />

--- a/web/src/components/DashboardSkeleton.tsx
+++ b/web/src/components/DashboardSkeleton.tsx
@@ -1,0 +1,156 @@
+'use client';
+
+import { useEffect, useState, type CSSProperties } from 'react';
+
+const SNAPSHOT_KEY = 'opaque:layout-snapshot';
+
+export interface LayoutSnapshotRow {
+  roots: string[];
+  widths: number[];
+}
+
+// Persisted after each successful dashboard load so the next visit's loading
+// frame mirrors the user's actual layout instead of a generic placeholder.
+export function saveLayoutSnapshot(rows: LayoutSnapshotRow[]) {
+  try {
+    window.localStorage.setItem(SNAPSHOT_KEY, JSON.stringify(rows));
+  } catch {
+    // Storage may be unavailable (private mode); the generic skeleton is fine.
+  }
+}
+
+function readLayoutSnapshot(): LayoutSnapshotRow[] | null {
+  try {
+    const raw = window.localStorage.getItem(SNAPSHOT_KEY);
+    if (!raw) return null;
+    const parsed: unknown = JSON.parse(raw);
+    if (!Array.isArray(parsed)) return null;
+    const rows = parsed.filter((row): row is LayoutSnapshotRow => (
+      Boolean(row)
+      && typeof row === 'object'
+      && Array.isArray((row as LayoutSnapshotRow).roots)
+      && Array.isArray((row as LayoutSnapshotRow).widths)
+      && (row as LayoutSnapshotRow).roots.length > 0
+    ));
+    return rows.length > 0 ? rows : null;
+  } catch {
+    return null;
+  }
+}
+
+const DEFAULT_ROWS: LayoutSnapshotRow[] = [
+  { roots: ['bookmarks', 'today'], widths: [50, 50] },
+  { roots: ['media', 'applications', 'posts'], widths: [33, 34, 33] },
+];
+
+const bar = 'rounded-sm bg-surface-sunken';
+const barSoft = 'rounded-sm bg-[#f1f1f1]';
+
+export default function DashboardSkeleton() {
+  // Start from the generic frame (matches SSR), then swap to the remembered
+  // layout right after mount so the skeleton mirrors the real structure.
+  const [rows, setRows] = useState<LayoutSnapshotRow[]>(DEFAULT_ROWS);
+
+  useEffect(() => {
+    const snapshot = readLayoutSnapshot();
+    if (snapshot) setRows(snapshot);
+  }, []);
+
+  return (
+    <div className="animate-fade-in py-16">
+      <div className="mx-4 md:mx-8">
+        <div className="h-0.5 w-6 bg-ink-300" />
+        <div className={`mt-3 h-3 w-44 animate-pulse ${barSoft}`} />
+      </div>
+
+      <div className="mx-4 mt-8 flex flex-col gap-5 md:mx-8">
+        {rows.map((row, rowIndex) => (
+          <div
+            key={rowIndex}
+            className="grid items-start gap-4 md:gap-5"
+            style={{
+              gridTemplateColumns: row.widths
+                .map((width) => `minmax(0, ${Math.max(width, 10)}fr)`)
+                .join(' '),
+            } as CSSProperties}
+          >
+            {row.roots.map((root, cellIndex) => (
+              <SectionSkeleton key={`${root}-${cellIndex}`} root={root} />
+            ))}
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+}
+
+function SectionSkeleton({ root }: { root: string }) {
+  return (
+    <section className="min-w-0">
+      <div className="mb-3 flex items-center gap-3">
+        <div className={`h-3.5 w-20 animate-pulse ${bar}`} />
+        <div className="h-px flex-1 bg-border-light" />
+      </div>
+      <SectionBodySkeleton root={root} />
+    </section>
+  );
+}
+
+function SectionBodySkeleton({ root }: { root: string }) {
+  if (root === 'today' || root === 'media') {
+    return (
+      <div className="flex animate-pulse flex-wrap gap-3">
+        {[0, 1].map((index) => (
+          <div key={index} className="w-72 max-w-full border border-border-light bg-white p-3">
+            <div className={`h-3 w-20 ${bar}`} />
+            <div className={`mt-4 h-2.5 w-3/4 ${barSoft}`} />
+            <div className={`mt-2 h-2.5 w-1/2 ${barSoft}`} />
+            <div className={`mt-2 h-2.5 w-2/3 ${barSoft}`} />
+            <div className={`mt-4 h-16 w-full ${barSoft}`} />
+          </div>
+        ))}
+      </div>
+    );
+  }
+
+  if (root === 'posts') {
+    return (
+      <div className="max-w-[732px] animate-pulse border border-border-light bg-white p-3">
+        <div className={`h-3 w-32 ${bar}`} />
+        <div className="mt-4 space-y-3.5">
+          {[0, 1, 2, 3].map((index) => (
+            <div key={index}>
+              <div className={`h-2.5 ${bar}`} style={{ width: `${80 - (index % 3) * 12}%` }} />
+              <div className={`mt-1.5 h-2 w-2/5 ${barSoft}`} />
+            </div>
+          ))}
+        </div>
+      </div>
+    );
+  }
+
+  if (root === 'servers') {
+    return (
+      <div className="w-[360px] max-w-full animate-pulse border border-border-light bg-white p-4">
+        <div className={`h-3 w-28 ${bar}`} />
+        <div className="mt-4 grid grid-cols-2 gap-3">
+          {[0, 1, 2, 3].map((index) => (
+            <div key={index}>
+              <div className={`h-2 w-12 ${barSoft}`} />
+              <div className={`mt-1.5 h-1.5 w-full ${barSoft}`} />
+            </div>
+          ))}
+        </div>
+      </div>
+    );
+  }
+
+  // bookmarks / applications / fallback: light text rows.
+  return (
+    <div className="max-w-md animate-pulse space-y-2.5 pt-1">
+      <div className={`h-3 w-28 ${bar}`} />
+      <div className={`h-2.5 w-3/5 ${barSoft}`} />
+      <div className={`h-2.5 w-2/5 ${barSoft}`} />
+    </div>
+  );
+}

--- a/web/src/components/Header.tsx
+++ b/web/src/components/Header.tsx
@@ -33,6 +33,8 @@ interface HeaderProps {
     isEditing?: boolean;
     isDirty?: boolean;
     isSaving?: boolean;
+    /** False while the dashboard is still an unverified cached paint. */
+    canEdit?: boolean;
     saveError?: string;
     onEdit?: () => void;
     onSave?: () => void;
@@ -44,6 +46,7 @@ export default function Header({
     isEditing = false,
     isDirty = false,
     isSaving = false,
+    canEdit = true,
     saveError = '',
     onEdit,
     onSave,
@@ -132,7 +135,7 @@ export default function Header({
                             </div>
                         )}
                         {saveError && (
-                            <div className="hidden max-w-48 truncate text-xs text-red-500 md:block">
+                            <div className="hidden max-w-48 truncate text-xs text-accent-red-dark md:block">
                                 {saveError}
                             </div>
                         )}
@@ -140,11 +143,12 @@ export default function Header({
                         {!isEditing && (
                             <button
                                 onClick={onEdit}
+                                disabled={!canEdit}
                                 className="opaque-toolbar-icon"
                                 aria-label="Edit dashboard"
-                                title="Edit dashboard"
+                                title={canEdit ? 'Edit dashboard' : 'Loading…'}
                             >
-                                <IconEdit />
+                                {canEdit ? <IconEdit /> : <IconLoader2 className="animate-spin" />}
                             </button>
                         )}
 

--- a/web/src/components/Tree/SectionAddControl.tsx
+++ b/web/src/components/Tree/SectionAddControl.tsx
@@ -66,7 +66,7 @@ export default function SectionAddControl({
       <button
         type="button"
         onClick={handleClick}
-        className="flex h-6 w-6 items-center justify-center rounded-sm border border-border-light bg-white text-text-muted transition-colors duration-150 hover:border-border-medium hover:text-text-primary"
+        className="flex h-6 w-6 items-center justify-center rounded-sm border border-border-light bg-white text-text-muted transition-colors hover:border-border-medium hover:text-text-primary"
         aria-label={label}
         aria-haspopup={options ? 'menu' : undefined}
         aria-expanded={options ? open : undefined}
@@ -89,7 +89,7 @@ export default function SectionAddControl({
                 onSelect?.(option.value);
                 setOpen(false);
               }}
-              className="flex w-full items-center px-3 py-1.5 text-left text-[11px] text-text-secondary transition-colors duration-150 hover:bg-surface-sunken hover:text-text-primary"
+              className="flex w-full items-center px-3 py-1.5 text-left text-[11px] text-text-secondary transition-colors hover:bg-surface-sunken hover:text-text-primary"
             >
               {option.label}
             </button>

--- a/web/src/components/Tree/TreeApplication.tsx
+++ b/web/src/components/Tree/TreeApplication.tsx
@@ -49,7 +49,7 @@ const TreeApplication: React.FC<TreeApplicationProps> = ({
   const draggedShelfPreview = useRef<DragPreviewState | null>(null);
   const draggedApplication = useRef<DraggedApplication | null>(null);
   const applicationInputClass =
-    'opaque-input w-full focus:border-accent-blue';
+    'opaque-input w-full focus:border-ink-700';
   const monoApplicationInputClass = `${applicationInputClass} font-mono text-[11px]`;
 
   const updateBranches = (branches: ApplicationBranch[]) => {
@@ -219,14 +219,14 @@ const TreeApplication: React.FC<TreeApplicationProps> = ({
             rel="noopener noreferrer"
             className="group block w-full max-w-[320px] min-w-0 text-inherit no-underline"
           >
-            <div className="flex min-h-[64px] items-center gap-2.5 rounded-sm px-1 py-2 transition-colors duration-200 hover:bg-white">
+            <div className="flex min-h-[64px] items-center gap-2.5 rounded-sm px-1 py-2 transition-colors hover:bg-white">
               <SvgIcon
                 svg={leaf.icon}
                 fallback={DEFAULT_APPLICATION_ICON}
-                className="h-10 w-10 flex-shrink-0 text-accent-blue transition-colors duration-200 group-hover:text-ink-800"
+                className="h-10 w-10 flex-shrink-0 text-text-secondary transition-colors group-hover:text-accent-green"
               />
               <div className="min-w-0 flex-1">
-                <div className="truncate text-sm font-medium leading-tight text-text-primary transition-colors duration-200 group-hover:text-accent-blue">
+                <div className="inline-block max-w-full truncate border-b border-transparent text-sm font-medium leading-tight text-text-primary transition-colors group-hover:border-accent-green">
                   {leaf.name}
                 </div>
                 <div className="mt-1 truncate font-mono text-xs leading-tight text-text-tertiary">
@@ -256,7 +256,7 @@ const TreeApplication: React.FC<TreeApplicationProps> = ({
         <section
           key={branch.id}
           data-drag-preview
-          className={`opaque-card p-4 transition-all duration-200 ${
+          className={`opaque-card p-4 transition-all ${
             activeDrag?.type === 'shelf' && activeDrag.id === branch.id
               ? 'scale-[0.99] opacity-45'
               : ''
@@ -300,12 +300,12 @@ const TreeApplication: React.FC<TreeApplicationProps> = ({
                 ...item,
                 name: event.target.value,
               }))}
-              className="min-w-0 flex-1 border-0 border-b border-border-light bg-transparent px-0 py-1 text-xs font-medium uppercase tracking-wider text-text-tertiary focus:border-accent-blue focus:ring-0"
+              className="min-w-0 flex-1 border-0 border-b border-border-light bg-transparent px-0 py-1 text-xs font-medium uppercase tracking-wider text-text-tertiary focus:border-ink-700 focus:ring-0"
             />
             <button
               type="button"
               onClick={() => removeShelf(branch.id)}
-              className="opaque-icon-button hover:text-red-500"
+              className="opaque-icon-button hover:text-accent-red-dark"
               aria-label={`Delete ${branch.name}`}
               title="Delete shelf"
             >
@@ -321,7 +321,7 @@ const TreeApplication: React.FC<TreeApplicationProps> = ({
                 <div
                   key={leaf.id}
                   data-drag-preview
-                  className={`group w-full max-w-[320px] rounded-sm border p-3 transition-all duration-200 ${
+                  className={`group w-full max-w-[320px] rounded-sm border p-3 transition-all ${
                     isLeafEditing
                       ? 'border-border-strong bg-white'
                       : 'border-transparent bg-transparent hover:bg-white'
@@ -391,7 +391,7 @@ const TreeApplication: React.FC<TreeApplicationProps> = ({
                         <button
                           type="button"
                           onClick={() => removeApplication(branch.id, leaf.id)}
-                          className="flex h-6 w-6 items-center justify-center rounded-sm text-text-muted hover:bg-surface-sunken hover:text-red-500"
+                          className="flex h-6 w-6 items-center justify-center rounded-sm text-text-muted hover:bg-surface-sunken hover:text-accent-red-dark"
                           aria-label={`Delete ${leaf.name}`}
                           title="Delete application"
                         >
@@ -422,7 +422,7 @@ const TreeApplication: React.FC<TreeApplicationProps> = ({
                       <SvgIcon
                         svg={leaf.icon}
                         fallback={DEFAULT_APPLICATION_ICON}
-                        className="h-9 w-9 flex-shrink-0 text-accent-blue"
+                        className="h-9 w-9 flex-shrink-0 text-text-secondary"
                       />
                       <div className="min-w-0 flex-1">
                         <div className="truncate text-sm font-medium leading-tight text-text-primary">
@@ -450,10 +450,10 @@ const TreeApplication: React.FC<TreeApplicationProps> = ({
             <button
               type="button"
               onClick={() => addApplication(branch.id)}
-              className="group flex min-h-[72px] w-full max-w-[320px] items-center gap-3 rounded-sm border border-dashed border-border-medium bg-white/60 p-3 text-left transition-colors hover:border-accent-blue hover:bg-white"
+              className="group flex min-h-[72px] w-full max-w-[320px] items-center gap-3 rounded-sm border border-dashed border-border-medium bg-white/60 p-3 text-left transition-colors hover:border-accent-green hover:bg-white"
               aria-label={`Add application to ${branch.name}`}
             >
-              <span className="flex h-10 w-10 flex-shrink-0 items-center justify-center text-text-tertiary transition-colors group-hover:text-accent-blue">
+              <span className="flex h-10 w-10 flex-shrink-0 items-center justify-center text-text-tertiary transition-colors group-hover:text-accent-green">
                 <IconPlus className="h-3.5 w-3.5" />
               </span>
               <span className="min-w-0 flex-1">

--- a/web/src/components/Tree/TreeBookmark.tsx
+++ b/web/src/components/Tree/TreeBookmark.tsx
@@ -49,7 +49,7 @@ const TreeBookmark: React.FC<TreeBookmarkProps> = ({
   const draggedBranchPreview = useRef<DragPreviewState | null>(null);
   const draggedLeaf = useRef<DraggedLeaf | null>(null);
   const bookmarkInputClass =
-    'opaque-input w-full focus:border-accent-green';
+    'opaque-input w-full focus:border-ink-700';
   const monoBookmarkInputClass = `${bookmarkInputClass} font-mono text-[11px]`;
 
   const updateBranches = (branches: BookmarkBranch[]) => {
@@ -202,7 +202,7 @@ const TreeBookmark: React.FC<TreeBookmarkProps> = ({
         <div
           key={branch.id}
           data-drag-preview
-          className={`relative flex w-full animate-fade-in flex-col p-4 transition-all duration-200 ease-in-out ${
+          className={`relative flex w-full animate-fade-in flex-col p-4 transition-all ${
             isEditing ? 'opaque-card' : ''
           } ${
             activeDrag?.type === 'branch' && activeDrag.id === branch.id
@@ -255,7 +255,7 @@ const TreeBookmark: React.FC<TreeBookmarkProps> = ({
                   ...item,
                   name: event.target.value,
                 }))}
-                className="min-w-0 flex-1 border-0 border-b border-border-light bg-transparent px-0 py-1 text-sm font-medium tracking-tight text-text-primary focus:border-accent-green focus:ring-0"
+                className="min-w-0 flex-1 border-0 border-b border-border-light bg-transparent px-0 py-1 text-sm font-medium tracking-tight text-text-primary focus:border-ink-700 focus:ring-0"
               />
             ) : (
               <div className="relative text-sm font-medium tracking-tight text-text-primary">
@@ -268,7 +268,7 @@ const TreeBookmark: React.FC<TreeBookmarkProps> = ({
               <button
                 type="button"
                 onClick={() => removeBranch(branch.id)}
-                className="flex h-6 w-6 items-center justify-center rounded-sm text-text-muted hover:bg-surface-sunken hover:text-red-500"
+                className="flex h-6 w-6 items-center justify-center rounded-sm text-text-muted hover:bg-surface-sunken hover:text-accent-red-dark"
                 aria-label={`Delete ${branch.name}`}
                 title="Delete group"
               >
@@ -286,7 +286,7 @@ const TreeBookmark: React.FC<TreeBookmarkProps> = ({
                   <div
                     key={leaf.id}
                     data-drag-preview
-                    className={`group rounded-sm border p-2 transition-all duration-200 ${
+                    className={`group rounded-sm border p-2 transition-all ${
                       isLeafEditing
                         ? 'border-border-strong bg-white'
                         : 'border-border-light bg-white/70 hover:bg-white'
@@ -356,7 +356,7 @@ const TreeBookmark: React.FC<TreeBookmarkProps> = ({
                           <button
                             type="button"
                             onClick={() => removeLeaf(branch.id, leaf.id)}
-                            className="flex h-6 w-6 items-center justify-center rounded-sm text-text-muted hover:bg-surface-sunken hover:text-red-500"
+                            className="flex h-6 w-6 items-center justify-center rounded-sm text-text-muted hover:bg-surface-sunken hover:text-accent-red-dark"
                             aria-label={`Delete ${leaf.name}`}
                             title="Delete bookmark"
                           >
@@ -418,17 +418,17 @@ const TreeBookmark: React.FC<TreeBookmarkProps> = ({
                   href={leaf.url || '#'}
                   target="_blank"
                   rel="noopener noreferrer"
-                  className="group block text-inherit no-underline transition-all duration-200 ease-in-out"
+                  className="group block text-inherit no-underline"
                 >
-                  <div className="relative px-1 py-1.5 transition-colors duration-200 hover:bg-white">
+                  <div className="relative rounded-sm px-1 py-1.5 transition-colors hover:bg-white">
                     <div className="flex items-center gap-1.5 text-left">
                       <SvgIcon
                         svg={leaf.icon}
                         fallback={DEFAULT_BOOKMARK_ICON}
-                        className="h-4 w-4 flex-shrink-0 text-text-secondary transition-colors duration-200 group-hover:text-accent-green"
+                        className="h-4 w-4 flex-shrink-0 text-text-secondary transition-colors group-hover:text-accent-green"
                       />
                       <div className="min-w-0 flex-1">
-                        <div className="inline-block max-w-full truncate border-b border-transparent text-xs font-normal leading-4 text-text-primary transition-colors duration-200 group-hover:border-accent-green">
+                        <div className="inline-block max-w-full truncate border-b border-transparent text-xs font-normal leading-4 text-text-primary transition-colors group-hover:border-accent-green">
                           {leaf.name}
                         </div>
                       </div>

--- a/web/src/components/Tree/TreeModule.tsx
+++ b/web/src/components/Tree/TreeModule.tsx
@@ -79,6 +79,11 @@ function moduleGridClassName(root: string) {
     return `${moduleGridBaseClass} grid-cols-[repeat(auto-fill,minmax(min(100%,732px),732px))]`;
   }
 
+  // Today widgets are glanceable summaries; a narrower column keeps them tidy.
+  if (root === 'today') {
+    return `${moduleGridBaseClass} grid-cols-[repeat(auto-fill,minmax(min(100%,320px),320px))]`;
+  }
+
   return `${moduleGridBaseClass} grid-cols-[repeat(auto-fill,minmax(min(100%,360px),360px))]`;
 }
 
@@ -376,7 +381,6 @@ const TreeModule: React.FC<TreeModuleProps> = ({
               <PostsStackWidget
                 key={`post-stack-${item.stackId}`}
                 modules={item.modules}
-                title="Posts"
               />
             );
           }
@@ -679,13 +683,29 @@ function CalendarWidget({ module }: { module: ModuleBranch }) {
   );
 }
 
+// Session-scoped cache of module data so remounts and tab switches show the
+// last known content instantly while a silent refresh runs in the background.
+const moduleDataCache = new Map<string, ModuleData>();
+
 function useModuleData(module: ModuleBranch): ModuleDataState {
-  const [data, setData] = useState<ModuleData | null>(null);
-  const [error, setError] = useState('');
-  const [isLoading, setIsLoading] = useState(true);
-  const [requestVersion, setRequestVersion] = useState(0);
   const configKey = JSON.stringify(module.config || {});
+  const cacheKey = `${module.id}:${configKey}`;
+  const [data, setData] = useState<ModuleData | null>(() => moduleDataCache.get(cacheKey) ?? null);
+  const [error, setError] = useState('');
+  const [isLoading, setIsLoading] = useState(() => !moduleDataCache.has(cacheKey));
+  const [requestVersion, setRequestVersion] = useState(0);
   const refresh = useCallback(() => setRequestVersion((version) => version + 1), []);
+
+  // When this hook instance is reused for a different module (switching tabs
+  // in a posts group), swap to that module's cached data during render so the
+  // previous tab's content never lingers under the new tab's header.
+  const lastCacheKeyRef = useRef(cacheKey);
+  if (lastCacheKeyRef.current !== cacheKey) {
+    lastCacheKeyRef.current = cacheKey;
+    setData(moduleDataCache.get(cacheKey) ?? null);
+    setError('');
+    setIsLoading(!moduleDataCache.has(cacheKey));
+  }
 
   useEffect(() => {
     const controller = new AbortController();
@@ -708,7 +728,9 @@ function useModuleData(module: ModuleBranch): ModuleDataState {
         }
 
         if (!cancelled) {
-          setData((payload as ModuleDataResponse).data);
+          const nextData = (payload as ModuleDataResponse).data;
+          moduleDataCache.set(cacheKey, nextData);
+          setData(nextData);
         }
       } catch (loadError) {
         if (!cancelled && !controller.signal.aborted) {
@@ -719,7 +741,8 @@ function useModuleData(module: ModuleBranch): ModuleDataState {
       }
     };
 
-    load();
+    // With cached data on screen, refresh silently (stale-while-revalidate).
+    load(moduleDataCache.has(cacheKey));
     const intervalId = window.setInterval(() => load(true), moduleRefreshInterval(module.moduleType));
 
     return () => {
@@ -727,9 +750,16 @@ function useModuleData(module: ModuleBranch): ModuleDataState {
       controller.abort();
       window.clearInterval(intervalId);
     };
-  }, [configKey, module.id, module.moduleType, requestVersion]);
+  }, [cacheKey, module.id, module.moduleType, requestVersion]);
 
   return { data, error, isLoading, refresh };
+}
+
+// Mounts the data hook for a module without rendering anything — used to warm
+// the cache for a posts group's hidden tabs so switching is instant.
+function ModulePrefetch({ module }: { module: ModuleBranch }) {
+  useModuleData(module);
+  return null;
 }
 
 function ModulePanel({
@@ -737,12 +767,15 @@ function ModulePanel({
   state,
   href,
   titleOverride,
+  header,
   children,
 }: {
   module: ModuleBranch;
   state?: ModuleDataState;
   href?: string;
   titleOverride?: string;
+  /** Replaces the icon + title cluster, e.g. a tab bar acting as the header. */
+  header?: React.ReactNode;
   children: React.ReactNode;
 }) {
   const statusClass = state?.error
@@ -755,23 +788,27 @@ function ModulePanel({
   return (
     <section className="border border-border-light bg-white p-3 transition-colors duration-200 hover:border-border-medium hover:bg-[#fcfcfc]">
       <div className="mb-4 flex items-center justify-between gap-3">
-        <div className="flex min-w-0 items-center gap-2">
-          <ModuleIcon moduleType={module.moduleType} className="h-4 w-4 text-text-secondary" />
-          {href ? (
-            <a
-              href={href}
-              target="_blank"
-              rel="noreferrer"
-              className="truncate font-serif text-sm text-text-primary no-underline hover:text-ink-800"
-            >
-              {title}
-            </a>
-          ) : (
-            <div className="truncate font-serif text-sm text-text-primary">
-              {title}
-            </div>
-          )}
-        </div>
+        {header ? (
+          <div className="min-w-0 flex-1">{header}</div>
+        ) : (
+          <div className="flex min-w-0 items-center gap-2">
+            <ModuleIcon moduleType={module.moduleType} className="h-4 w-4 text-text-secondary" />
+            {href ? (
+              <a
+                href={href}
+                target="_blank"
+                rel="noreferrer"
+                className="truncate font-serif text-sm text-text-primary no-underline hover:text-ink-800"
+              >
+                {title}
+              </a>
+            ) : (
+              <div className="truncate font-serif text-sm text-text-primary">
+                {title}
+              </div>
+            )}
+          </div>
+        )}
         {state && (
           <div className="flex items-center gap-2">
             <button
@@ -801,7 +838,7 @@ function WeatherWidget({ module, state }: { module: ModuleBranch; state: ModuleD
   return (
     <ModulePanel module={module} state={state}>
       {!data ? (
-        <ModuleBodyState state={state} />
+        <ModuleBodyState state={state} skeleton="weather" />
       ) : (
         <>
           <div>
@@ -846,7 +883,7 @@ function MarketsWidget({ module, state }: { module: ModuleBranch; state: ModuleD
   return (
     <ModulePanel module={module} state={state}>
       {!data ? (
-        <ModuleBodyState state={state} />
+        <ModuleBodyState state={state} skeleton="markets" />
       ) : (
         <div className="-my-1 divide-y divide-border-light">
           {data.quotes.map((quote) => {
@@ -889,16 +926,16 @@ function MarketSparkline({
 }: {
   values: number[];
 }) {
-  const points = sparklinePoints(values, 96, 34);
+  const points = sparklinePoints(values, 80, 26);
 
   if (!points) {
-    return <div className="h-9" />;
+    return <div className="h-[26px]" />;
   }
 
   return (
-    <div className="h-9 min-w-0 overflow-hidden">
+    <div className="h-[26px] min-w-0 overflow-hidden">
       <svg
-        viewBox="0 0 96 34"
+        viewBox="0 0 80 26"
         preserveAspectRatio="none"
         className="h-full w-full text-ink-400"
         aria-label="Recent price trend"
@@ -930,7 +967,7 @@ function MediaWidget({ module, state }: { module: ModuleBranch; state: ModuleDat
   return (
     <ModulePanel module={module} state={state} href={data?.url}>
       {!data ? (
-        <ModuleBodyState state={state} />
+        <ModuleBodyState state={state} skeleton="media" />
       ) : (
         <>
           <div className="mb-4 flex items-baseline justify-between">
@@ -1194,18 +1231,19 @@ function PostsStackEditor({
       onDrop={onDrop}
     >
       <div className="mb-3 flex items-center justify-between gap-3">
-        <div className="font-serif text-sm text-text-primary">Posts group</div>
-        <div className="font-mono text-[10px] text-text-muted">
+        <div className="min-w-0 flex-1">
+          <PostStackTabs
+            modules={modules}
+            selectedId={selectedModule.id}
+            onSelect={setSelectedId}
+            getTabDragProps={getTabDragProps}
+            framed={false}
+          />
+        </div>
+        <div className="flex-shrink-0 font-mono text-[10px] text-text-muted">
           {modules.length} sources · tabs
         </div>
       </div>
-
-      <PostStackTabs
-        modules={modules}
-        selectedId={selectedModule.id}
-        onSelect={setSelectedId}
-        getTabDragProps={getTabDragProps}
-      />
 
       <div className="mt-2">
         {renderModule(selectedModule)}
@@ -1216,10 +1254,8 @@ function PostsStackEditor({
 
 function PostsStackWidget({
   modules,
-  title = 'Posts',
 }: {
   modules: ModuleBranch[];
-  title?: string;
 }) {
   const sources = useMemo(() => (
     modules.filter((module) => isPostModuleType(module.moduleType))
@@ -1239,7 +1275,6 @@ function PostsStackWidget({
       modules={sources}
       selectedModule={selectedModule}
       onSelect={setSelectedId}
-      title={title}
     />
   );
 }
@@ -1248,24 +1283,33 @@ function PostsStackLive({
   modules,
   selectedModule,
   onSelect,
-  title,
 }: {
   modules: ModuleBranch[];
   selectedModule: ModuleBranch;
   onSelect: (moduleId: string) => void;
-  title: string;
 }) {
   const state = useModuleData(selectedModule);
   const data = state.data?.kind === 'posts' ? state.data as PostsModuleData : null;
 
   return (
-    <ModulePanel module={selectedModule} state={state} titleOverride={title}>
-      <PostStackTabs
-        modules={modules}
-        selectedId={selectedModule.id}
-        onSelect={onSelect}
-      />
+    <ModulePanel
+      module={selectedModule}
+      state={state}
+      header={(
+        <PostStackTabs
+          modules={modules}
+          selectedId={selectedModule.id}
+          onSelect={onSelect}
+          framed={false}
+        />
+      )}
+    >
       <PostsContent data={data} state={state} />
+      {modules
+        .filter((source) => source.id !== selectedModule.id)
+        .map((source) => (
+          <ModulePrefetch key={source.id} module={source} />
+        ))}
     </ModulePanel>
   );
 }
@@ -1275,15 +1319,22 @@ function PostStackTabs({
   selectedId,
   onSelect,
   getTabDragProps,
+  framed = true,
 }: {
   modules: ModuleBranch[];
   selectedId: string;
   onSelect: (moduleId: string) => void;
   getTabDragProps?: (moduleId: string) => TabDragProps;
+  /** false renders a bare tab row (no baseline rule) for use as a panel header. */
+  framed?: boolean;
 }) {
   const draggable = Boolean(getTabDragProps);
   return (
-    <div className="mb-3 flex min-w-0 flex-wrap items-end gap-4 border-b border-border-light">
+    <div
+      className={`flex min-w-0 flex-wrap items-end gap-4 ${
+        framed ? 'mb-3 border-b border-border-light' : ''
+      }`}
+    >
       {modules.map((source) => {
         const isSelected = source.id === selectedId;
         const dragProps = getTabDragProps?.(source.id);
@@ -1293,7 +1344,9 @@ function PostStackTabs({
             type="button"
             onClick={() => onSelect(source.id)}
             {...dragProps}
-            className={`group relative -mb-px pb-2 text-[10px] uppercase tracking-wider transition-colors ${
+            className={`group relative text-[10px] uppercase tracking-wider transition-colors ${
+              framed ? '-mb-px pb-2' : 'pb-1'
+            } ${
               draggable ? 'cursor-grab active:cursor-grabbing' : ''
             } ${
               isSelected
@@ -1335,7 +1388,7 @@ function PostsContent({
   data: PostsModuleData | null;
   state: ModuleDataState;
 }) {
-  if (!data) return <ModuleBodyState state={state} />;
+  if (!data) return <ModuleBodyState state={state} skeleton="posts" />;
   if (data.posts.length === 0) return <EmptyModuleState>No posts found.</EmptyModuleState>;
 
   return (
@@ -1367,10 +1420,118 @@ function PostsContent({
   );
 }
 
-function ModuleBodyState({ state }: { state: ModuleDataState }) {
+type ModuleSkeletonKind = 'weather' | 'markets' | 'media' | 'posts' | 'generic';
+
+function ModuleBodyState({
+  state,
+  skeleton = 'generic',
+}: {
+  state: ModuleDataState;
+  skeleton?: ModuleSkeletonKind;
+}) {
+  if (state.error) {
+    return (
+      <div className="min-h-16 text-[11px] leading-relaxed text-red-500">
+        {state.error}
+      </div>
+    );
+  }
+
+  return <ModuleSkeleton kind={skeleton} />;
+}
+
+const skeletonBar = 'rounded-sm bg-surface-sunken';
+const skeletonBarSoft = 'rounded-sm bg-[#f1f1f1]';
+
+// Loading placeholders that echo each module's real content structure, so the
+// panel doesn't reshape when live data arrives.
+function ModuleSkeleton({ kind }: { kind: ModuleSkeletonKind }) {
+  if (kind === 'weather') {
+    return (
+      <div className="animate-pulse" aria-hidden>
+        <div className={`h-8 w-20 ${skeletonBar}`} />
+        <div className={`mt-2 h-2.5 w-24 ${skeletonBarSoft}`} />
+        <div className={`mt-4 h-2 w-36 ${skeletonBarSoft}`} />
+        <div className="mt-4 grid grid-cols-3 gap-2 border-t border-border-light pt-3">
+          {[0, 1, 2].map((index) => (
+            <div key={index}>
+              <div className={`h-2 w-8 ${skeletonBarSoft}`} />
+              <div className={`mt-1.5 h-2.5 w-12 ${skeletonBar}`} />
+            </div>
+          ))}
+        </div>
+      </div>
+    );
+  }
+
+  if (kind === 'markets') {
+    return (
+      <div className="-my-1 animate-pulse divide-y divide-border-light" aria-hidden>
+        {[0, 1, 2, 3].map((index) => (
+          <div key={index} className="grid grid-cols-[minmax(4.75rem,0.9fr)_minmax(4.25rem,1fr)_minmax(4.5rem,auto)] items-center gap-3 py-2.5">
+            <div>
+              <div className={`h-2.5 w-12 ${skeletonBar}`} />
+              <div className={`mt-1.5 h-2 w-16 ${skeletonBarSoft}`} />
+            </div>
+            <div className={`h-[26px] w-full ${skeletonBarSoft}`} />
+            <div className="justify-self-end">
+              <div className={`h-2.5 w-12 ${skeletonBar}`} />
+              <div className={`mt-1.5 h-2 w-14 ${skeletonBarSoft}`} />
+            </div>
+          </div>
+        ))}
+      </div>
+    );
+  }
+
+  if (kind === 'media') {
+    return (
+      <div className="animate-pulse" aria-hidden>
+        <div className="mb-4 flex items-baseline justify-between">
+          <div className={`h-2 w-12 ${skeletonBar}`} />
+          <div className={`h-2 w-16 ${skeletonBarSoft}`} />
+        </div>
+        <div className="grid grid-cols-2 gap-3">
+          {[0, 1].map((index) => (
+            <div key={index}>
+              <div className={`h-2 w-14 ${skeletonBarSoft}`} />
+              <div className={`mt-1.5 h-3.5 w-10 ${skeletonBar}`} />
+            </div>
+          ))}
+        </div>
+        <div className="mt-4 border-t border-border-light pt-3">
+          <div className={`h-2 w-24 ${skeletonBarSoft}`} />
+          <div className="mt-2 grid grid-cols-4 gap-2">
+            {[0, 1, 2, 3].map((index) => (
+              <div key={index}>
+                <div className={`aspect-[2/3] ${skeletonBar}`} />
+                <div className={`mt-1.5 h-2 w-full ${skeletonBarSoft}`} />
+              </div>
+            ))}
+          </div>
+        </div>
+      </div>
+    );
+  }
+
+  if (kind === 'posts') {
+    return (
+      <div className="animate-pulse space-y-3.5" aria-hidden>
+        {[0, 1, 2, 3, 4].map((index) => (
+          <div key={index}>
+            <div className={`h-2.5 ${skeletonBar}`} style={{ width: `${82 - (index % 3) * 14}%` }} />
+            <div className={`mt-1.5 h-2 w-2/5 ${skeletonBarSoft}`} />
+          </div>
+        ))}
+      </div>
+    );
+  }
+
   return (
-    <div className={`min-h-16 text-[11px] leading-relaxed ${state.error ? 'text-red-500' : 'text-text-tertiary'}`}>
-      {state.error || 'Loading live data...'}
+    <div className="min-h-16 animate-pulse space-y-2.5" aria-hidden>
+      <div className={`h-2.5 w-3/4 ${skeletonBar}`} />
+      <div className={`h-2.5 w-1/2 ${skeletonBarSoft}`} />
+      <div className={`h-2.5 w-2/3 ${skeletonBarSoft}`} />
     </div>
   );
 }

--- a/web/src/components/Tree/TreeModule.tsx
+++ b/web/src/components/Tree/TreeModule.tsx
@@ -20,17 +20,20 @@ import {
   IconRefresh,
   IconRss,
   IconTrash,
+  IconX,
 } from '@tabler/icons-react';
 import type {
   MarketsModuleData,
   MediaModuleData,
   MediaNowPlayingItem,
   MediaQueueItem,
+  MediaRecentItem,
   ModuleData,
   ModuleDataResponse,
   PostsModuleData,
   WeatherModuleData,
 } from '@/lib/moduleData';
+import { isPostRead, markPostRead, subscribeReadPosts } from '@/lib/readPosts';
 import { KnownModuleType, ModuleBranch } from '@/lib/types';
 import {
   createDefaultModuleBranch,
@@ -442,8 +445,8 @@ function ModuleEditCard({
 }: ModuleEditCardProps) {
   const mergeRing = isMergeTarget ? 'border-ink-700 bg-[#fcfcfc]' : '';
   const shellClassName = embedded
-    ? `relative transition-all duration-200 ${activeDragId === module.id ? 'scale-[0.98] opacity-45' : ''}`
-    : `group relative border bg-white p-3 transition-all duration-200 ${
+    ? `relative transition-all ${activeDragId === module.id ? 'scale-[0.98] opacity-45' : ''}`
+    : `group relative border bg-white p-3 transition-all ${
         mergeRing || 'border-border-light hover:border-border-medium'
       } ${activeDragId === module.id ? 'scale-[0.98] opacity-45' : ''}`;
 
@@ -502,7 +505,7 @@ function ModuleEditCard({
         <button
           type="button"
           onClick={onRemove}
-          className="flex h-6 w-6 items-center justify-center rounded-sm text-text-muted hover:bg-surface-sunken hover:text-red-500"
+          className="flex h-6 w-6 items-center justify-center rounded-sm text-text-muted hover:bg-surface-sunken hover:text-accent-red-dark"
           aria-label={`Delete ${module.name}`}
           title="Delete module"
         >
@@ -779,14 +782,14 @@ function ModulePanel({
   children: React.ReactNode;
 }) {
   const statusClass = state?.error
-    ? 'bg-red-500'
+    ? 'bg-accent-red'
     : state?.isLoading
       ? 'bg-ink-300'
       : 'bg-accent-green';
   const title = titleOverride || module.name || getModuleLabel(module.moduleType);
 
   return (
-    <section className="border border-border-light bg-white p-3 transition-colors duration-200 hover:border-border-medium hover:bg-[#fcfcfc]">
+    <section className="relative border border-border-light bg-white p-3 transition-colors hover:border-border-medium hover:bg-[#fcfcfc]">
       <div className="mb-4 flex items-center justify-between gap-3">
         {header ? (
           <div className="min-w-0 flex-1">{header}</div>
@@ -963,6 +966,16 @@ function MediaWidget({ module, state }: { module: ModuleBranch; state: ModuleDat
   const streamCount = data
     ? Math.max(nowPlaying.length, toCount(mediaStatValue(data, 'Streams')))
     : 0;
+  const [zoomedRecent, setZoomedRecent] = useState<MediaRecentItem | null>(null);
+
+  useEffect(() => {
+    if (!zoomedRecent) return;
+    const onKeyDown = (event: KeyboardEvent) => {
+      if (event.key === 'Escape') setZoomedRecent(null);
+    };
+    window.addEventListener('keydown', onKeyDown);
+    return () => window.removeEventListener('keydown', onKeyDown);
+  }, [zoomedRecent]);
 
   return (
     <ModulePanel module={module} state={state} href={data?.url}>
@@ -1070,51 +1083,133 @@ function MediaWidget({ module, state }: { module: ModuleBranch; state: ModuleDat
               </div>
               <div className="grid grid-cols-4 gap-2">
                 {data.recent.map((item) => (
-                  <div key={item.id} className="group/recent min-w-0">
-                    <div className="relative aspect-[2/3] overflow-hidden border border-border-light bg-surface-sunken">
-                      {item.imageUrl ? (
-                        <Image
-                          src={item.imageUrl}
-                          alt={`${item.title} cover`}
-                          width={72}
-                          height={108}
-                          loading="lazy"
-                          unoptimized
-                          className="h-full w-full object-cover"
-                        />
-                      ) : (
-                        <div className="flex h-full w-full items-center justify-center text-[10px] text-text-muted">
-                          {item.title.slice(0, 1)}
-                        </div>
-                      )}
-                      {item.addedAt && (
-                        <div className="pointer-events-none absolute inset-x-0 bottom-0 bg-gradient-to-t from-black/70 to-transparent px-1 pb-0.5 pt-3 text-center font-mono text-[8px] text-white/90 opacity-0 transition-opacity group-hover/recent:opacity-100">
-                          {formatRelativeTime(item.addedAt)}
-                        </div>
-                      )}
-                    </div>
-                    <div
-                      className="mt-1 line-clamp-2 text-[10px] font-medium leading-tight text-text-primary"
-                      title={item.title}
-                    >
-                      {item.title}
-                    </div>
-                    {item.subtitle && (
-                      <div
-                        className="mt-0.5 line-clamp-2 font-mono text-[9px] leading-tight text-text-tertiary"
-                        title={item.subtitle}
-                      >
-                        {item.subtitle}
-                      </div>
-                    )}
-                  </div>
+                  <MediaRecentCell key={item.id} item={item} onZoom={setZoomedRecent} />
                 ))}
               </div>
             </div>
           )}
+          {zoomedRecent && (
+            <MediaPosterZoom item={zoomedRecent} onClose={() => setZoomedRecent(null)} />
+          )}
         </>
       )}
     </ModulePanel>
+  );
+}
+
+function MediaRecentCell({
+  item,
+  onZoom,
+}: {
+  item: MediaRecentItem;
+  onZoom: (item: MediaRecentItem) => void;
+}) {
+  const body = (
+    <>
+      <div className="relative aspect-[2/3] overflow-hidden border border-border-light bg-surface-sunken transition-colors group-hover/recent:border-border-medium">
+        {item.imageUrl ? (
+          <Image
+            src={item.imageUrl}
+            alt={`${item.title} cover`}
+            width={72}
+            height={108}
+            loading="lazy"
+            unoptimized
+            className="h-full w-full object-cover"
+          />
+        ) : (
+          <div className="flex h-full w-full items-center justify-center text-[10px] text-text-muted">
+            {item.title.slice(0, 1)}
+          </div>
+        )}
+        {item.addedAt && (
+          <div className="pointer-events-none absolute inset-x-0 bottom-0 bg-gradient-to-t from-black/70 to-transparent px-1 pb-0.5 pt-3 text-center font-mono text-[8px] text-white/90 opacity-0 transition-opacity group-hover/recent:opacity-100">
+            {formatRelativeTime(item.addedAt)}
+          </div>
+        )}
+      </div>
+      <div
+        className="mt-1 line-clamp-2 text-[10px] font-medium leading-tight text-text-primary"
+        title={item.title}
+      >
+        {item.title}
+      </div>
+      {item.subtitle && (
+        <div
+          className="mt-0.5 line-clamp-2 font-mono text-[9px] leading-tight text-text-tertiary"
+          title={item.subtitle}
+        >
+          {item.subtitle}
+        </div>
+      )}
+    </>
+  );
+
+  // Only covers with real artwork zoom; letter placeholders stay inert.
+  if (!item.imageUrl) {
+    return <div className="group/recent min-w-0">{body}</div>;
+  }
+
+  return (
+    <button
+      type="button"
+      onClick={() => onZoom(item)}
+      aria-haspopup="dialog"
+      aria-label={`Enlarge ${item.title} cover`}
+      className="group/recent block w-full min-w-0 cursor-zoom-in text-left"
+    >
+      {body}
+    </button>
+  );
+}
+
+// In-panel lightbox: the cover enlarges inside its own module instead of a
+// full-screen modal, keeping the rest of the page quiet.
+function MediaPosterZoom({
+  item,
+  onClose,
+}: {
+  item: MediaRecentItem;
+  onClose: () => void;
+}) {
+  return (
+    <div
+      role="dialog"
+      aria-modal="true"
+      aria-label={item.title}
+      onClick={onClose}
+      className="absolute inset-0 z-20 flex animate-poster-zoom cursor-zoom-out flex-col items-center justify-center gap-3 bg-white/95 p-5"
+    >
+      <button
+        type="button"
+        autoFocus
+        onClick={onClose}
+        aria-label="Close"
+        className="absolute right-2 top-2 flex h-6 w-6 items-center justify-center rounded-sm text-text-muted transition-colors hover:bg-surface-sunken hover:text-text-primary"
+      >
+        <IconX className="h-3.5 w-3.5" />
+      </button>
+      <div className="flex min-h-0 w-full flex-1 items-center justify-center">
+        <Image
+          src={item.imageUrl ?? ''}
+          alt={`${item.title} cover`}
+          width={300}
+          height={450}
+          unoptimized
+          className="h-full w-auto max-w-full border border-border-light object-contain shadow-elevated"
+        />
+      </div>
+      <div className="max-w-full text-center">
+        <div className="truncate font-serif text-sm text-text-primary">{item.title}</div>
+        {(item.subtitle || item.addedAt) && (
+          <div className="mt-0.5 truncate font-mono text-[10px] text-text-tertiary">
+            {item.subtitle}
+            {item.subtitle && item.addedAt && ' · '}
+            {item.addedAt && `added ${formatRelativeTime(item.addedAt)}`}
+          </div>
+        )}
+      </div>
+    </div>
   );
 }
 
@@ -1224,7 +1319,7 @@ function PostsStackEditor({
 
   return (
     <div
-      className={`border bg-white p-3 transition-colors duration-200 ${
+      className={`border bg-white p-3 transition-colors ${
         isDropTarget ? 'border-ink-700 bg-[#fcfcfc]' : 'border-border-light hover:border-border-medium'
       }`}
       onDragOver={onDragOver}
@@ -1381,6 +1476,13 @@ function PostsWidget({ module, state }: { module: ModuleBranch; state: ModuleDat
   );
 }
 
+// Re-renders when post read-state changes, here or in another tab.
+function useReadPosts() {
+  const [, setVersion] = useState(0);
+  useEffect(() => subscribeReadPosts(() => setVersion((value) => value + 1)), []);
+  return { isRead: isPostRead, markRead: markPostRead };
+}
+
 function PostsContent({
   data,
   state,
@@ -1388,34 +1490,53 @@ function PostsContent({
   data: PostsModuleData | null;
   state: ModuleDataState;
 }) {
+  const { isRead, markRead } = useReadPosts();
+
   if (!data) return <ModuleBodyState state={state} skeleton="posts" />;
-  if (data.posts.length === 0) return <EmptyModuleState>No posts found.</EmptyModuleState>;
+  if (data.posts.length === 0) return <EmptyModuleState>Nothing new today.</EmptyModuleState>;
 
   return (
     <div className="-mx-2 space-y-0.5">
-      {data.posts.map((post) => (
-        <a
-          key={post.id}
-          href={post.url}
-          target="_blank"
-          rel="noreferrer"
-          className="group relative block rounded-sm px-2 py-1.5 text-inherit no-underline transition-colors duration-200 hover:bg-surface-sunken/70"
-        >
-          <span
-            aria-hidden
-            className="absolute inset-y-1 left-0 w-px origin-top scale-y-0 bg-accent-green transition-transform duration-200 group-hover:scale-y-100"
-          />
-          <div className="line-clamp-2 text-xs leading-relaxed text-text-primary transition-colors duration-200 group-hover:text-ink-900">
-            {post.title}
-          </div>
-          <div className="mt-1 flex items-center gap-2 font-mono text-[10px] text-text-tertiary transition-colors duration-200 group-hover:text-text-secondary">
-            <span>{post.source}</span>
-            {(post.meta || post.publishedAt) && <span>·</span>}
-            {post.meta && <span className="truncate">{post.meta}</span>}
-            {post.publishedAt && <span className="flex-shrink-0">{formatRelativeTime(post.publishedAt)}</span>}
-          </div>
-        </a>
-      ))}
+      {data.posts.map((post) => {
+        const read = isRead(post.url);
+        return (
+          <a
+            key={post.id}
+            href={post.url}
+            target="_blank"
+            rel="noreferrer"
+            onClick={() => markRead(post.url)}
+            onAuxClick={(event) => {
+              if (event.button === 1) markRead(post.url);
+            }}
+            className="group relative block rounded-sm px-2 py-1.5 text-inherit no-underline transition-colors hover:bg-surface-sunken/70"
+          >
+            <span
+              aria-hidden
+              className="absolute inset-y-1 left-0 w-px origin-top scale-y-0 bg-accent-green transition-transform group-hover:scale-y-100"
+            />
+            <div
+              className={`line-clamp-2 text-xs leading-relaxed transition-colors ${
+                read
+                  ? 'text-text-tertiary group-hover:text-text-secondary'
+                  : 'text-text-primary group-hover:text-ink-900'
+              }`}
+            >
+              {post.title}
+            </div>
+            <div
+              className={`mt-1 flex items-center gap-2 font-mono text-[10px] transition-colors ${
+                read ? 'text-text-muted' : 'text-text-tertiary group-hover:text-text-secondary'
+              }`}
+            >
+              <span>{post.source}</span>
+              {(post.meta || post.publishedAt) && <span>·</span>}
+              {post.meta && <span className="truncate">{post.meta}</span>}
+              {post.publishedAt && <span className="flex-shrink-0">{formatRelativeTime(post.publishedAt)}</span>}
+            </div>
+          </a>
+        );
+      })}
     </div>
   );
 }
@@ -1431,7 +1552,7 @@ function ModuleBodyState({
 }) {
   if (state.error) {
     return (
-      <div className="min-h-16 text-[11px] leading-relaxed text-red-500">
+      <div className="min-h-16 text-[11px] leading-relaxed text-accent-red-dark">
         {state.error}
       </div>
     );
@@ -1895,7 +2016,7 @@ function ConfigFieldLabel({
         <span className="group/help relative inline-flex">
           <button
             type="button"
-            className="flex h-4 w-4 items-center justify-center rounded-full text-text-muted hover:bg-surface-sunken hover:text-text-primary focus:outline-none focus:ring-1 focus:ring-ink-500"
+            className="flex h-4 w-4 items-center justify-center rounded-full text-text-muted hover:bg-surface-sunken hover:text-text-primary"
             aria-label={`${label} help`}
           >
             <IconHelpCircle className="h-3 w-3" />

--- a/web/src/components/Tree/TreeServer.tsx
+++ b/web/src/components/Tree/TreeServer.tsx
@@ -269,7 +269,7 @@ const TreeServer: React.FC<TreeServerProps> = ({
           <div
             key={server.id}
             data-drag-preview
-            className={`relative w-[360px] max-w-full flex-none rounded-sm border bg-white p-4 transition-all duration-200 ${
+            className={`relative w-[360px] max-w-full flex-none rounded-sm border bg-white p-4 transition-all ${
               isServerEditing
                 ? 'border-border-strong'
                 : 'border-border-light hover:border-border-medium hover:bg-[#fcfcfc]'
@@ -331,7 +331,7 @@ const TreeServer: React.FC<TreeServerProps> = ({
                     <button
                       type="button"
                       onClick={() => copyAgentId(server.id)}
-                      className="flex h-6 w-6 items-center justify-center rounded-sm text-text-muted hover:bg-white hover:text-text-primary"
+                      className="flex h-6 w-6 items-center justify-center rounded-sm text-text-muted hover:bg-surface-sunken hover:text-text-primary"
                       aria-label="Copy agent id"
                       title="Copy agent id"
                     >
@@ -346,7 +346,7 @@ const TreeServer: React.FC<TreeServerProps> = ({
                       type="button"
                       onClick={() => rotateAgentToken(server.id)}
                       disabled={rotatingTokenId === server.id}
-                      className="flex h-6 items-center gap-1 rounded-sm px-2 text-[11px] text-text-secondary hover:bg-white hover:text-text-primary disabled:opacity-50"
+                      className="flex h-6 items-center gap-1 rounded-sm px-2 text-[11px] text-text-secondary hover:bg-surface-sunken hover:text-text-primary disabled:opacity-50"
                     >
                       {rotatingTokenId === server.id ? (
                         <IconRefresh className="h-3.5 w-3.5 animate-spin" />
@@ -364,7 +364,7 @@ const TreeServer: React.FC<TreeServerProps> = ({
                       <button
                         type="button"
                         onClick={() => copyAgentToken(server.id)}
-                        className="flex h-6 w-6 items-center justify-center rounded-sm text-text-muted hover:bg-white hover:text-text-primary"
+                        className="flex h-6 w-6 items-center justify-center rounded-sm text-text-muted hover:bg-surface-sunken hover:text-text-primary"
                         aria-label="Copy agent token"
                         title="Copy agent token"
                       >
@@ -373,7 +373,7 @@ const TreeServer: React.FC<TreeServerProps> = ({
                     </div>
                   )}
                   {agentTokenErrors[server.id] && (
-                    <div className="mt-1 text-[11px] leading-relaxed text-red-500">
+                    <div className="mt-1 text-[11px] leading-relaxed text-accent-red-dark">
                       {agentTokenErrors[server.id]}
                     </div>
                   )}
@@ -390,7 +390,7 @@ const TreeServer: React.FC<TreeServerProps> = ({
                   <button
                     type="button"
                     onClick={() => removeServer(server.id)}
-                    className="flex h-6 w-6 items-center justify-center rounded-sm text-text-muted hover:bg-surface-sunken hover:text-red-500"
+                    className="flex h-6 w-6 items-center justify-center rounded-sm text-text-muted hover:bg-surface-sunken hover:text-accent-red-dark"
                     aria-label={`Delete ${server.name}`}
                     title="Delete server"
                   >
@@ -496,7 +496,7 @@ function MetricBar({
       </div>
       <div className="h-1.5 w-full overflow-hidden rounded-full bg-surface-sunken">
         <div
-          className={`h-full rounded-full transition-all duration-300 ${normalized < 70 ? 'bg-accent-green' : normalized < 90 ? 'bg-amber-500' : 'bg-red-500'}`}
+          className={`h-full rounded-full transition-all ${normalized < 70 ? 'bg-accent-green' : normalized < 90 ? 'bg-accent-amber' : 'bg-accent-red'}`}
           style={{ width: `${normalized}%` }}
         />
       </div>

--- a/web/src/lib/readPosts.ts
+++ b/web/src/lib/readPosts.ts
@@ -1,0 +1,74 @@
+// Read-state for post links, kept in localStorage so it survives visits
+// without touching the server. Keyed by URL — feed item ids can change
+// between fetches, urls don't.
+
+const STORAGE_KEY = 'opaque:read-posts';
+const MAX_ENTRIES = 1000;
+
+let cache: Set<string> | null = null;
+const listeners = new Set<() => void>();
+let storageListenerAttached = false;
+
+function load(): Set<string> {
+  if (typeof window === 'undefined') return new Set();
+  try {
+    const raw = window.localStorage.getItem(STORAGE_KEY);
+    if (!raw) return new Set();
+    const parsed: unknown = JSON.parse(raw);
+    if (!Array.isArray(parsed)) return new Set();
+    return new Set(parsed.filter((entry): entry is string => typeof entry === 'string'));
+  } catch {
+    return new Set();
+  }
+}
+
+function persist(entries: Set<string>) {
+  try {
+    // Oldest first in insertion order; keep the most recent MAX_ENTRIES.
+    const list = Array.from(entries).slice(-MAX_ENTRIES);
+    window.localStorage.setItem(STORAGE_KEY, JSON.stringify(list));
+  } catch {
+    // Storage unavailable (private mode / quota): read-state stays in-memory.
+  }
+}
+
+function notify() {
+  listeners.forEach((listener) => listener());
+}
+
+function readSet(): Set<string> {
+  if (!cache) cache = load();
+  return cache;
+}
+
+export function isPostRead(url: string): boolean {
+  return readSet().has(url);
+}
+
+export function markPostRead(url: string) {
+  if (!url) return;
+  const set = readSet();
+  if (set.has(url)) return;
+  set.add(url);
+  if (set.size > MAX_ENTRIES) {
+    cache = new Set(Array.from(set).slice(-MAX_ENTRIES));
+  }
+  persist(readSet());
+  notify();
+}
+
+/** Re-renders subscribers when read-state changes here or in another tab. */
+export function subscribeReadPosts(listener: () => void): () => void {
+  listeners.add(listener);
+  if (!storageListenerAttached && typeof window !== 'undefined') {
+    storageListenerAttached = true;
+    window.addEventListener('storage', (event) => {
+      if (event.key !== STORAGE_KEY) return;
+      cache = null;
+      notify();
+    });
+  }
+  return () => {
+    listeners.delete(listener);
+  };
+}

--- a/web/tailwind.config.js
+++ b/web/tailwind.config.js
@@ -16,6 +16,8 @@ module.exports = {
         'accent-red': '#A76767',
         'accent-red-dark': '#8E5555',
         'accent-red-subtle': 'rgba(167, 103, 103, 0.08)',
+        'accent-amber': '#B08D57',
+        'accent-amber-dark': '#97784A',
         'accent-blue': '#5E6AD2',
         'accent-blue-subtle': 'rgba(94, 106, 210, 0.08)',
         'accent-blue-hover': 'rgba(94, 106, 210, 0.15)',
@@ -57,6 +59,14 @@ module.exports = {
         'subtle': '0 1px 2px rgba(0, 0, 0, 0.04)',
         'elevated': '0 2px 8px rgba(0, 0, 0, 0.08)',
         'floating': '0 4px 16px rgba(0, 0, 0, 0.12)',
+      },
+      // The single motion budget (see web/DESIGN_SPEC.md): every `transition-*`
+      // without an explicit duration/easing uses these.
+      transitionDuration: {
+        DEFAULT: '180ms',
+      },
+      transitionTimingFunction: {
+        DEFAULT: 'cubic-bezier(0.2, 0.6, 0.2, 1)',
       },
     },
   },


### PR DESCRIPTION
## Summary

A perceived-performance and refinement pass across first load, posts groups, and layout proportions.

## 1. First-load skeletons (structure-matched)

The home page is fully client-rendered and nothing painted until `/api/dashboard/get` returned — on a slow DB round-trip the user stared at a centered "Loading dashboard…" line.

- New **`DashboardSkeleton`**: a quiet structural frame shown while the dashboard loads. It mirrors the user's **actual layout** via a snapshot persisted to `localStorage` after each successful load (`rows → roots + widths`), with per-root placeholder shapes (cards for today/media, list bars for posts, stat grid for servers). Generic two-row frame on first visit.
- **Per-module skeletons**: module bodies render structure-matched placeholders (weather / markets / media / posts) instead of "Loading live data…" text, so panels don't reshape when data arrives.

Verified by temporarily delaying the dashboard API 15s — the skeleton frame mirrors the saved 3-row layout exactly (screenshot in session).

## 2. Posts groups: instant tab switching + tabs-as-header

- **Bug**: switching tabs showed the *previous* tab's posts under the new tab's header until the new fetch finished. `useModuleData` now keeps a session-scoped **cache per module**, resets its state during render when its module changes (no stale content), and group members are **prefetched** via hidden hooks — verified in-browser: content swaps to the new tab's posts in the same frame as the click.
- **The tab bar is now the panel header** (view + edit modes). The redundant "Posts" / "Posts group" title rows are gone; refresh + status stay on the right.

## 3. Layout polish

- **Today** widgets: 360px → **320px** columns; markets **sparkline shrunk to 80×26** to match.
- **Welcome** heading: the large serif title is now a single small line — time-of-day greeting + date ("Good evening, Paul — Wednesday, June 10").

## Verification

- Page skeleton verified against a 15s-delayed API (temp change, reverted; route untouched in diff).
- Tab switch: DOM-verified instant swap from prefetch cache; no skeleton flash.
- Live data: real Plex session rendered in Now Playing during testing.
- `tsc --noEmit`, `eslint`, `next build` all pass. No data mutations.

🤖 Generated with [Claude Code](https://claude.com/claude-code)