### PR TITLE
feat(dashboard): keyboard shortcuts, notifications tray, trimmed avatar menu, edit polish

### DIFF
--- a/web/src/app/page.tsx
+++ b/web/src/app/page.tsx
@@ -1,6 +1,6 @@
 'use client'
 
-import { useEffect, useMemo, useState } from 'react'
+import { useCallback, useEffect, useMemo, useState } from 'react'
 import { useRouter } from 'next/navigation'
 import TreeBookmark from '@/components/Tree/TreeBookmark'
 import TreeApplication from '@/components/Tree/TreeApplication'
@@ -10,6 +10,9 @@ import Header from '@/components/Header'
 import Footer from '@/components/Footer'
 import DashboardLayoutEditor from '@/components/DashboardLayoutEditor'
 import DashboardOnboarding, { OnboardingDraft } from '@/components/DashboardOnboarding'
+import ShortcutsOverlay from '@/components/ShortcutsOverlay'
+import { useKeyboardShortcuts, type KeyboardShortcut } from '@/lib/useKeyboardShortcuts'
+import { useNotifications } from '@/lib/useNotifications'
 import {
   buildSkeletonForest,
   readSnapshotRows,
@@ -48,7 +51,12 @@ export default function HomePage() {
   // there is no unverified copy that could be edited and saved over newer
   // server state.
   const [isVerified, setIsVerified] = useState(false)
+  const [showShortcuts, setShowShortcuts] = useState(false)
   const router = useRouter()
+
+  // System notifications derived from live server status (online↔offline). Fed
+  // the verified, stats-merged dashboard so events reflect real transitions.
+  const { notifications, unreadCount, markAllRead } = useNotifications(dashboard)
 
   useEffect(() => {
     const fetchDashboard = async () => {
@@ -167,7 +175,7 @@ export default function HomePage() {
       : skeletonForest
   ), [visibleDashboard, isEditing, skeletonForest])
 
-  const startEditing = () => {
+  const startEditing = useCallback(() => {
     // Editing is only safe once the server copy is confirmed: editing an
     // unverified cached paint risks saving stale data over newer server state.
     if (!dashboard || !isVerified) return
@@ -175,18 +183,18 @@ export default function HomePage() {
     setIsEditing(true)
     setIsDirty(false)
     setSaveError('')
-  }
+  }, [dashboard, isVerified])
 
-  const resetEditing = () => {
+  const resetEditing = useCallback(() => {
     if (dashboard) {
       setDraftDashboard(cloneDashboard(dashboard))
     }
     setIsEditing(false)
     setIsDirty(false)
     setSaveError('')
-  }
+  }, [dashboard])
 
-  const saveDashboard = async () => {
+  const saveDashboard = useCallback(async () => {
     // `isVerified` is the invariant that makes saving safe — never write a
     // draft derived from an unverified cached paint back to the server.
     if (!draftDashboard || !isDirty || !isVerified) return
@@ -220,7 +228,7 @@ export default function HomePage() {
     } finally {
       setIsSaving(false)
     }
-  }
+  }, [draftDashboard, isDirty, isVerified])
 
   const updateTree = (tree: Tree) => {
     setDraftDashboard((current) => {
@@ -255,6 +263,30 @@ export default function HomePage() {
     setIsDirty(true)
     setSaveError('')
   }
+
+  const focusSearch = useCallback(() => {
+    const input = document.getElementById('search') as HTMLInputElement | null
+    input?.focus()
+    input?.select()
+  }, [])
+
+  // Core keyboard layer. Handlers stay silent while typing in a field (the hook
+  // gates that), so '/', 'e', '?' don't disrupt text entry.
+  const shortcuts = useMemo<KeyboardShortcut[]>(() => [
+    { key: '/', handler: focusSearch },
+    { key: 'e', handler: () => { if (!isEditing) startEditing() } },
+    { key: 's', meta: true, allowInInput: true, handler: () => { if (isEditing) void saveDashboard() } },
+    {
+      key: 'Escape',
+      handler: () => {
+        if (showShortcuts) setShowShortcuts(false)
+        else if (isEditing) resetEditing()
+      },
+    },
+    { key: '?', handler: () => setShowShortcuts((value) => !value) },
+  ], [focusSearch, isEditing, showShortcuts, startEditing, saveDashboard, resetEditing])
+
+  useKeyboardShortcuts(shortcuts, !loading && !error)
 
   if (error) {
     return (
@@ -320,6 +352,9 @@ export default function HomePage() {
         isSaving={isSaving}
         canEdit={isVerified}
         saveError={saveError}
+        notifications={notifications}
+        unreadCount={unreadCount}
+        onNotificationsOpen={markAllRead}
         onEdit={startEditing}
         onReset={resetEditing}
         onSave={saveDashboard}
@@ -364,6 +399,7 @@ export default function HomePage() {
         </div>
       </div>
       <Footer />
+      {showShortcuts && <ShortcutsOverlay onClose={() => setShowShortcuts(false)} />}
     </div>
   )
 }

--- a/web/src/app/page.tsx
+++ b/web/src/app/page.tsx
@@ -13,6 +13,7 @@ import DashboardOnboarding, { OnboardingDraft } from '@/components/DashboardOnbo
 import ShortcutsOverlay from '@/components/ShortcutsOverlay'
 import { useKeyboardShortcuts, type KeyboardShortcut } from '@/lib/useKeyboardShortcuts'
 import { useNotifications } from '@/lib/useNotifications'
+import { isOverlayOpen } from '@/lib/overlay'
 import {
   buildSkeletonForest,
   readSnapshotRows,
@@ -282,8 +283,14 @@ export default function HomePage() {
     {
       key: 'Escape',
       handler: () => {
-        if (showShortcuts) setShowShortcuts(false)
-        else if (isEditing) resetEditing()
+        if (showShortcuts) {
+          setShowShortcuts(false)
+          return
+        }
+        // An open menu/dialog owns Escape (closes itself); don't also discard
+        // an in-progress edit. Overlays mark themselves with data-overlay.
+        if (isOverlayOpen()) return
+        if (isEditing) resetEditing()
       },
     },
     { key: '?', handler: () => setShowShortcuts((value) => !value) },

--- a/web/src/app/page.tsx
+++ b/web/src/app/page.tsx
@@ -197,7 +197,10 @@ export default function HomePage() {
   const saveDashboard = useCallback(async () => {
     // `isVerified` is the invariant that makes saving safe — never write a
     // draft derived from an unverified cached paint back to the server.
-    if (!draftDashboard || !isDirty || !isVerified) return
+    // `isSaving` gate matches the Save button: the Cmd/Ctrl+S shortcut must not
+    // fire a second PUT while one is in flight (a stale response could land last
+    // and reset the dashboard).
+    if (!draftDashboard || !isDirty || !isVerified || isSaving) return
 
     setIsSaving(true)
     setSaveError('')
@@ -228,7 +231,7 @@ export default function HomePage() {
     } finally {
       setIsSaving(false)
     }
-  }, [draftDashboard, isDirty, isVerified])
+  }, [draftDashboard, isDirty, isVerified, isSaving])
 
   const updateTree = (tree: Tree) => {
     setDraftDashboard((current) => {

--- a/web/src/components/Header.tsx
+++ b/web/src/components/Header.tsx
@@ -218,7 +218,7 @@ export default function Header({
                                 {avatarInitial}
                             </button>
                             {showAvatarDropdown && (
-                                <div className="opaque-menu-popover">
+                                <div className="opaque-menu-popover" data-overlay>
                                     <div className="opaque-menu-panel">
                                         <div className="opaque-menu-summary">
                                             <div className="text-xs font-medium leading-relaxed">

--- a/web/src/components/Header.tsx
+++ b/web/src/components/Header.tsx
@@ -4,20 +4,14 @@ import { useEffect, useRef, useState } from 'react';
 import { usePathname, useRouter } from 'next/navigation';
 import {
     IconCheck,
-    IconChevronRight,
     IconDeviceFloppy,
     IconEdit,
-    IconInfoCircle,
-    IconLayoutDashboard,
     IconLoader2,
     IconLogout,
     IconMessageCircle,
-    IconPalette,
     IconRefresh,
     IconSearch,
     IconServer,
-    IconSettings,
-    IconUser,
 } from '@tabler/icons-react';
 import { Dashboard, ServerBranch } from '@/lib/types';
 import {
@@ -27,6 +21,8 @@ import {
     SEARCH_PROVIDERS,
     type SearchProviderId,
 } from '@/lib/searchProviders';
+import NotificationsMenu from '@/components/NotificationsMenu';
+import type { AppNotification } from '@/lib/useNotifications';
 
 interface HeaderProps {
     dashboard?: Dashboard | null;
@@ -36,6 +32,9 @@ interface HeaderProps {
     /** False while the dashboard is still an unverified cached paint. */
     canEdit?: boolean;
     saveError?: string;
+    notifications?: AppNotification[];
+    unreadCount?: number;
+    onNotificationsOpen?: () => void;
     onEdit?: () => void;
     onSave?: () => void;
     onReset?: () => void;
@@ -48,6 +47,9 @@ export default function Header({
     isSaving = false,
     canEdit = true,
     saveError = '',
+    notifications = [],
+    unreadCount = 0,
+    onNotificationsOpen,
     onEdit,
     onSave,
     onReset,
@@ -123,7 +125,11 @@ export default function Header({
                                 autoComplete="off"
                                 className="peer opaque-input w-[min(22rem,34vw)] pr-8"
                             />
-                            <IconSearch className="pointer-events-none absolute right-2.5 top-1/2 h-3.5 w-3.5 -translate-y-1/2 text-text-tertiary" />
+                            <IconSearch className="pointer-events-none absolute right-2.5 top-1/2 h-3.5 w-3.5 -translate-y-1/2 text-text-tertiary peer-focus:opacity-0" />
+                            {/* '/' focuses search (see useKeyboardShortcuts); hint hides once focused. */}
+                            <kbd className="pointer-events-none absolute right-2 top-1/2 hidden h-4 w-4 -translate-y-1/2 items-center justify-center rounded-sm border border-border-medium bg-surface-sunken font-mono text-[10px] text-text-tertiary peer-placeholder-shown:flex peer-focus:hidden">
+                                /
+                            </kbd>
                         </form>
                     </div>
 
@@ -196,6 +202,12 @@ export default function Header({
                             {serverSummary.online}/{serverSummary.total}
                         </div>
 
+                        <NotificationsMenu
+                            notifications={notifications}
+                            unreadCount={unreadCount}
+                            onOpen={() => onNotificationsOpen?.()}
+                        />
+
                         <div className="relative" ref={avatarRef}>
                             <button
                                 onClick={() => setShowAvatarDropdown((value) => !value)}
@@ -225,10 +237,7 @@ export default function Header({
                                             </div>
                                         </div>
 
-                                        <button
-                                            type="button"
-                                            className="opaque-menu-profile"
-                                        >
+                                        <div className="opaque-menu-profile cursor-default">
                                             <span className="opaque-menu-avatar">
                                                 {avatarInitial}
                                             </span>
@@ -236,28 +245,10 @@ export default function Header({
                                                 <span className="block truncate text-xs font-semibold text-text-primary">
                                                     {displayName}
                                                 </span>
-                                                <span className="mt-0.5 block truncate text-[11px] text-text-tertiary">
-                                                    View profile
+                                                <span className="mt-0.5 block truncate font-mono text-[11px] text-text-tertiary">
+                                                    {accountLabel}
                                                 </span>
                                             </span>
-                                        </button>
-
-                                        <div className="opaque-menu-section">
-                                            <MenuItem
-                                                icon={<IconLayoutDashboard />}
-                                                label="Dashboard"
-                                                onClick={() => setShowAvatarDropdown(false)}
-                                            />
-                                            <MenuItem
-                                                icon={<IconUser />}
-                                                label="Personal settings"
-                                                badge="Soon"
-                                            />
-                                            <MenuItem
-                                                icon={<IconPalette />}
-                                                label="Theme"
-                                                trailing={<IconChevronRight />}
-                                            />
                                         </div>
 
                                         <div className="opaque-menu-section px-3.5 py-2.5">
@@ -284,38 +275,18 @@ export default function Header({
 
                                         <div className="opaque-menu-section">
                                             <MenuItem
-                                                icon={<IconServer />}
-                                                label="Server monitor"
-                                                detail={`${serverSummary.online}/${serverSummary.total}`}
-                                            />
-                                            <MenuItem
-                                                icon={<IconSettings />}
-                                                label="Workspace settings"
-                                                badge="Soon"
-                                            />
-                                            <MenuItem
                                                 icon={<IconMessageCircle />}
                                                 label="Send feedback"
                                                 onClick={() => {
                                                     window.location.href = 'mailto:feedback@opaque.local?subject=OPAQUE feedback';
                                                 }}
                                             />
-                                            <MenuItem
-                                                icon={<IconInfoCircle />}
-                                                label="About"
-                                            />
-                                        </div>
-
-                                        <div className="opaque-menu-account">
-                                            <div className="truncate">
-                                                {accountLabel}
-                                            </div>
                                         </div>
 
                                         <button
                                             type="button"
                                             onClick={handleLogout}
-                                            className="opaque-menu-item border-t border-border-light"
+                                            className="opaque-menu-item"
                                         >
                                             <span className="opaque-menu-item-icon">
                                                 <IconLogout />
@@ -336,16 +307,10 @@ export default function Header({
 function MenuItem({
     icon,
     label,
-    detail,
-    badge,
-    trailing,
     onClick,
 }: {
     icon: React.ReactNode;
     label: string;
-    detail?: string;
-    badge?: string;
-    trailing?: React.ReactNode;
     onClick?: () => void;
 }) {
     return (
@@ -358,17 +323,6 @@ function MenuItem({
                 {icon}
             </span>
             <span className="min-w-0 flex-1 truncate">{label}</span>
-            {detail && (
-                <span className="opaque-menu-detail">{detail}</span>
-            )}
-            {badge && (
-                <span className="opaque-menu-badge">
-                    {badge}
-                </span>
-            )}
-            {trailing && (
-                <span className="opaque-menu-item-trailing text-text-tertiary">{trailing}</span>
-            )}
         </button>
     );
 }

--- a/web/src/components/NotificationsMenu.tsx
+++ b/web/src/components/NotificationsMenu.tsx
@@ -1,0 +1,127 @@
+'use client';
+
+import { useEffect, useRef, useState } from 'react';
+import { IconBell } from '@tabler/icons-react';
+import type { AppNotification } from '@/lib/useNotifications';
+
+interface NotificationsMenuProps {
+  notifications: AppNotification[];
+  unreadCount: number;
+  onOpen: () => void;
+}
+
+const TONE_DOT: Record<AppNotification['tone'], string> = {
+  positive: 'bg-accent-green',
+  negative: 'bg-accent-red',
+  neutral: 'bg-ink-300',
+};
+
+// Short relative time for the notification timescale ("just now" … "3d ago").
+function relativeTime(at: number): string {
+  const seconds = Math.max(0, Math.round((Date.now() - at) / 1000));
+  if (seconds < 45) return 'just now';
+  const minutes = Math.round(seconds / 60);
+  if (minutes < 60) return `${minutes}m ago`;
+  const hours = Math.round(minutes / 60);
+  if (hours < 24) return `${hours}h ago`;
+  const days = Math.round(hours / 24);
+  return `${days}d ago`;
+}
+
+// Steam-style notification tray: a bell with an unread badge and a quiet
+// dropdown of recent system events. Opening marks everything read.
+export default function NotificationsMenu({
+  notifications,
+  unreadCount,
+  onOpen,
+}: NotificationsMenuProps) {
+  const [open, setOpen] = useState(false);
+  const ref = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    if (!open) return;
+    const onClickOutside = (event: MouseEvent) => {
+      if (ref.current && !ref.current.contains(event.target as Node)) setOpen(false);
+    };
+    const onKeyDown = (event: KeyboardEvent) => {
+      if (event.key === 'Escape') setOpen(false);
+    };
+    document.addEventListener('mousedown', onClickOutside);
+    document.addEventListener('keydown', onKeyDown);
+    return () => {
+      document.removeEventListener('mousedown', onClickOutside);
+      document.removeEventListener('keydown', onKeyDown);
+    };
+  }, [open]);
+
+  const toggle = () => {
+    setOpen((value) => {
+      const next = !value;
+      if (next) onOpen(); // Mark read on open, like Steam.
+      return next;
+    });
+  };
+
+  return (
+    <div className="relative" ref={ref}>
+      <button
+        type="button"
+        onClick={toggle}
+        className="opaque-toolbar-icon relative"
+        aria-label={unreadCount > 0 ? `Notifications, ${unreadCount} unread` : 'Notifications'}
+        aria-expanded={open}
+      >
+        <IconBell />
+        {unreadCount > 0 && (
+          <span className="absolute -right-0.5 -top-0.5 flex h-3.5 min-w-[0.875rem] items-center justify-center rounded-full bg-accent-red px-1 font-mono text-[9px] font-medium leading-none text-white">
+            {unreadCount > 9 ? '9+' : unreadCount}
+          </span>
+        )}
+      </button>
+
+      {open && (
+        <div className="opaque-menu-popover">
+          <div className="opaque-menu-panel">
+            <div className="flex items-center justify-between border-b border-border-light px-3.5 py-2.5">
+              <span className="font-serif text-sm text-text-primary">Notifications</span>
+              {notifications.length > 0 && (
+                <span className="font-mono text-[10px] text-text-tertiary">
+                  {notifications.length}
+                </span>
+              )}
+            </div>
+
+            {notifications.length === 0 ? (
+              <div className="px-3.5 py-6 text-center text-xs text-text-tertiary">
+                Nothing new.
+              </div>
+            ) : (
+              <div className="max-h-80 divide-y divide-border-light overflow-y-auto">
+                {notifications.map((notification) => (
+                  <div key={notification.id} className="flex items-start gap-2.5 px-3.5 py-2.5">
+                    <span
+                      className={`mt-1 h-1.5 w-1.5 flex-shrink-0 rounded-full ${TONE_DOT[notification.tone]}`}
+                    />
+                    <div className="min-w-0 flex-1">
+                      <div className="text-xs leading-relaxed text-text-primary">
+                        {notification.title}
+                      </div>
+                      {notification.detail && (
+                        <div className="mt-0.5 text-[11px] leading-relaxed text-text-tertiary">
+                          {notification.detail}
+                        </div>
+                      )}
+                      <div className="mt-1 font-mono text-[10px] text-text-muted">
+                        {relativeTime(notification.at)}
+                      </div>
+                    </div>
+                  </div>
+                ))}
+              </div>
+            )}
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/web/src/components/NotificationsMenu.tsx
+++ b/web/src/components/NotificationsMenu.tsx
@@ -80,7 +80,7 @@ export default function NotificationsMenu({
       </button>
 
       {open && (
-        <div className="opaque-menu-popover">
+        <div className="opaque-menu-popover" data-overlay>
           <div className="opaque-menu-panel">
             <div className="flex items-center justify-between border-b border-border-light px-3.5 py-2.5">
               <span className="font-serif text-sm text-text-primary">Notifications</span>

--- a/web/src/components/ShortcutsOverlay.tsx
+++ b/web/src/components/ShortcutsOverlay.tsx
@@ -1,0 +1,75 @@
+'use client';
+
+import { useEffect } from 'react';
+import { IconX } from '@tabler/icons-react';
+
+interface ShortcutRow {
+  keys: string[];
+  label: string;
+}
+
+const SHORTCUTS: ShortcutRow[] = [
+  { keys: ['/'], label: 'Focus search' },
+  { keys: ['E'], label: 'Edit dashboard' },
+  { keys: ['⌘', 'S'], label: 'Save changes' },
+  { keys: ['Esc'], label: 'Exit edit · close overlay' },
+  { keys: ['?'], label: 'Show this list' },
+];
+
+// A quiet, centered cheat-sheet (the '?' overlay). Follows Quiet
+// Instrumentality: serif title, hairline divider, mono keycaps, no decoration.
+export default function ShortcutsOverlay({ onClose }: { onClose: () => void }) {
+  useEffect(() => {
+    const onKeyDown = (event: KeyboardEvent) => {
+      if (event.key === 'Escape') {
+        event.preventDefault();
+        onClose();
+      }
+    };
+    window.addEventListener('keydown', onKeyDown);
+    return () => window.removeEventListener('keydown', onKeyDown);
+  }, [onClose]);
+
+  return (
+    <div
+      role="dialog"
+      aria-modal="true"
+      aria-label="Keyboard shortcuts"
+      onClick={onClose}
+      className="fixed inset-0 z-[80] flex animate-fade-in items-center justify-center bg-ink-900/20 p-4"
+    >
+      <div
+        onClick={(event) => event.stopPropagation()}
+        className="relative w-full max-w-sm rounded-sm border border-border-light bg-white p-5 shadow-floating"
+      >
+        <button
+          type="button"
+          onClick={onClose}
+          aria-label="Close"
+          className="absolute right-2 top-2 flex h-6 w-6 items-center justify-center rounded-sm text-text-muted transition-colors hover:bg-surface-sunken hover:text-text-primary"
+        >
+          <IconX className="h-3.5 w-3.5" />
+        </button>
+
+        <div className="font-serif text-sm text-text-primary">Keyboard shortcuts</div>
+        <div className="mt-3 divide-y divide-border-light border-t border-border-light">
+          {SHORTCUTS.map((row) => (
+            <div key={row.label} className="flex items-center justify-between gap-4 py-2">
+              <span className="text-xs text-text-secondary">{row.label}</span>
+              <span className="flex flex-shrink-0 items-center gap-1">
+                {row.keys.map((key) => (
+                  <kbd
+                    key={key}
+                    className="inline-flex h-5 min-w-[1.25rem] items-center justify-center rounded-sm border border-border-medium bg-surface-sunken px-1.5 font-mono text-[10px] text-text-secondary"
+                  >
+                    {key}
+                  </kbd>
+                ))}
+              </span>
+            </div>
+          ))}
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/web/src/components/Tree/TreeModule.tsx
+++ b/web/src/components/Tree/TreeModule.tsx
@@ -20,6 +20,7 @@ import {
   IconPhotoVideo,
   IconPlayerPause,
   IconPlayerPlay,
+  IconPlus,
   IconRefresh,
   IconRss,
   IconTrash,
@@ -343,6 +344,30 @@ const TreeModule: React.FC<TreeModuleProps> = ({
       </div>
     </div>
   ) : null;
+
+  // An empty module root in edit mode shows an inline "add" affordance in the
+  // body — without it the section is just a title with nothing beneath it and
+  // only a floating control, which reads as broken. Single-module roots offer
+  // their one fixed module directly; multi-module roots open the picker.
+  if (isEditing && visibleModules.length === 0 && allowedTypes.length > 0) {
+    const singleType = isSingleModuleRoot(tree.root) ? allowedTypes[0] : null;
+    return (
+      <div className="relative">
+        {!singleType && addControl}
+        <button
+          type="button"
+          onClick={() => singleType && addModule(singleType)}
+          disabled={!singleType}
+          className="group flex min-h-[72px] w-full max-w-[320px] items-center justify-center gap-2 rounded-sm border border-dashed border-border-medium bg-white/60 p-3 text-xs text-text-tertiary transition-colors enabled:hover:border-accent-green enabled:hover:text-text-primary disabled:opacity-60"
+        >
+          <IconPlus className="h-3.5 w-3.5" />
+          {singleType
+            ? `Add ${MODULE_LABELS[singleType]}`
+            : 'Use the + above to add a module'}
+        </button>
+      </div>
+    );
+  }
 
   return (
     <div className="relative">

--- a/web/src/lib/overlay.ts
+++ b/web/src/lib/overlay.ts
@@ -1,0 +1,11 @@
+// A transient overlay/menu (dropdown, dialog, cheat-sheet) marks itself with
+// `data-overlay` while open. Window-level shortcuts (notably the global Escape
+// that exits edit mode) consult this so an Escape meant to close an open menu
+// doesn't also discard an in-progress edit. This is robust to event ordering —
+// it queries the DOM at handler time rather than relying on stopPropagation.
+export const OVERLAY_ATTR = 'data-overlay';
+
+export function isOverlayOpen(): boolean {
+  if (typeof document === 'undefined') return false;
+  return document.querySelector(`[${OVERLAY_ATTR}]`) !== null;
+}

--- a/web/src/lib/useKeyboardShortcuts.ts
+++ b/web/src/lib/useKeyboardShortcuts.ts
@@ -1,0 +1,59 @@
+import { useEffect } from 'react';
+
+export interface KeyboardShortcut {
+  /** `event.key` to match, compared case-insensitively (e.g. 'e', '/', '?'). */
+  key: string;
+  /** Require the platform command key (⌘ on macOS, Ctrl elsewhere). */
+  meta?: boolean;
+  handler: (event: KeyboardEvent) => void;
+  /** Fire even when focus is in an input/textarea/contenteditable. */
+  allowInInput?: boolean;
+}
+
+// True when the user is typing into a field — most shortcuts must stay silent
+// there so normal text entry (including '/', '?', 'e') isn't hijacked.
+function isEditableTarget(target: EventTarget | null): boolean {
+  if (!(target instanceof HTMLElement)) return false;
+  const tag = target.tagName;
+  return (
+    tag === 'INPUT'
+    || tag === 'TEXTAREA'
+    || tag === 'SELECT'
+    || target.isContentEditable
+  );
+}
+
+function matchesMeta(event: KeyboardEvent, wantsMeta: boolean | undefined): boolean {
+  const hasMeta = event.metaKey || event.ctrlKey;
+  return wantsMeta ? hasMeta : !hasMeta;
+}
+
+// A small global keyboard layer. Shortcuts are matched on keydown; the first
+// match wins and gets preventDefault. Re-binds whenever `shortcuts` changes, so
+// callers should memoize handlers or accept the cheap re-subscribe.
+export function useKeyboardShortcuts(
+  shortcuts: KeyboardShortcut[],
+  enabled = true,
+): void {
+  useEffect(() => {
+    if (!enabled) return;
+
+    const onKeyDown = (event: KeyboardEvent) => {
+      if (event.altKey) return; // Leave Alt combos to the browser/OS.
+      const inField = isEditableTarget(event.target);
+
+      for (const shortcut of shortcuts) {
+        if (event.key.toLowerCase() !== shortcut.key.toLowerCase()) continue;
+        if (!matchesMeta(event, shortcut.meta)) continue;
+        if (inField && !shortcut.allowInInput) continue;
+
+        event.preventDefault();
+        shortcut.handler(event);
+        return;
+      }
+    };
+
+    window.addEventListener('keydown', onKeyDown);
+    return () => window.removeEventListener('keydown', onKeyDown);
+  }, [shortcuts, enabled]);
+}

--- a/web/src/lib/useNotifications.ts
+++ b/web/src/lib/useNotifications.ts
@@ -1,0 +1,110 @@
+import { useCallback, useEffect, useRef, useState } from 'react';
+import { Dashboard, ServerBranch } from '@/lib/types';
+
+export interface AppNotification {
+  id: string;
+  /** Tone drives the status dot color; stays within the muted palette. */
+  tone: 'positive' | 'negative' | 'neutral';
+  title: string;
+  detail?: string;
+  /** Epoch ms when the event was observed (client clock). */
+  at: number;
+}
+
+// Persist only the "last seen" timestamp (a number) — never notification text,
+// which can include user-named servers. Unread = created after lastSeen.
+const LAST_SEEN_KEY = 'opaque:notifications-last-seen';
+const MAX_NOTIFICATIONS = 50;
+const SERVER_STALE_MS = 30 * 1000;
+
+type ServerState = 'online' | 'offline';
+
+function serverState(server: ServerBranch): ServerState {
+  const updatedAt = server.stats?.updatedAt
+    ? new Date(server.stats.updatedAt).getTime()
+    : Number.NaN;
+  const fresh = Number.isFinite(updatedAt) && Date.now() - updatedAt <= SERVER_STALE_MS;
+  return server.stats?.status === 'online' && fresh ? 'online' : 'offline';
+}
+
+function serverBranches(dashboard: Dashboard | null): ServerBranch[] {
+  const branches = dashboard?.forest.find((tree) => tree.root === 'servers')?.branches;
+  return Array.isArray(branches) ? (branches as ServerBranch[]) : [];
+}
+
+function readLastSeen(): number {
+  try {
+    const raw = window.localStorage.getItem(LAST_SEEN_KEY);
+    const value = raw ? Number(raw) : 0;
+    return Number.isFinite(value) ? value : 0;
+  } catch {
+    return 0;
+  }
+}
+
+// Observes dashboard server statuses and emits a notification on each
+// online↔offline transition. Derived entirely client-side from data already on
+// screen — no new backend. The first observation seeds a baseline silently so a
+// reload doesn't replay every server's current state as an "event".
+export function useNotifications(dashboard: Dashboard | null) {
+  const [notifications, setNotifications] = useState<AppNotification[]>([]);
+  const [lastSeen, setLastSeen] = useState(0);
+  const prevStatesRef = useRef<Map<string, ServerState> | null>(null);
+
+  useEffect(() => {
+    setLastSeen(readLastSeen());
+  }, []);
+
+  useEffect(() => {
+    if (!dashboard) return;
+    const servers = serverBranches(dashboard);
+    const nextStates = new Map<string, ServerState>();
+    servers.forEach((server) => nextStates.set(server.id, serverState(server)));
+
+    const prev = prevStatesRef.current;
+    prevStatesRef.current = nextStates;
+    // First pass just records the baseline — don't emit for pre-existing state.
+    if (prev === null) return;
+
+    const fresh: AppNotification[] = [];
+    nextStates.forEach((state, id) => {
+      const before = prev.get(id);
+      if (before === undefined || before === state) return;
+      const server = servers.find((item) => item.id === id);
+      const name = server?.name || 'A server';
+      if (state === 'offline') {
+        fresh.push({
+          id: `${id}:offline:${Date.now()}`,
+          tone: 'negative',
+          title: `${name} went offline`,
+          at: Date.now(),
+        });
+      } else {
+        fresh.push({
+          id: `${id}:online:${Date.now()}`,
+          tone: 'positive',
+          title: `${name} is back online`,
+          at: Date.now(),
+        });
+      }
+    });
+
+    if (fresh.length > 0) {
+      setNotifications((current) => [...fresh, ...current].slice(0, MAX_NOTIFICATIONS));
+    }
+  }, [dashboard]);
+
+  const markAllRead = useCallback(() => {
+    const now = Date.now();
+    setLastSeen(now);
+    try {
+      window.localStorage.setItem(LAST_SEEN_KEY, String(now));
+    } catch {
+      // Storage unavailable; unread state stays in-memory for this session.
+    }
+  }, []);
+
+  const unreadCount = notifications.filter((notification) => notification.at > lastSeen).length;
+
+  return { notifications, unreadCount, markAllRead };
+}

--- a/web/src/lib/useNotifications.ts
+++ b/web/src/lib/useNotifications.ts
@@ -58,8 +58,15 @@ export function useNotifications(dashboard: Dashboard | null) {
   useEffect(() => {
     if (!dashboard) return;
     const servers = serverBranches(dashboard);
+    // Only servers that have reported metrics are tracked. /api/dashboard/get
+    // returns the forest without live `stats`; the metrics poll merges them in
+    // shortly after. Including a stat-less server here would baseline it as
+    // "offline", then the first poll would flip an actually-online server
+    // offline→online and fire a spurious "is back online" on every load.
     const nextStates = new Map<string, ServerState>();
-    servers.forEach((server) => nextStates.set(server.id, serverState(server)));
+    servers.forEach((server) => {
+      if (server.stats) nextStates.set(server.id, serverState(server));
+    });
 
     const prev = prevStatesRef.current;
     prevStatesRef.current = nextStates;


### PR DESCRIPTION
## What & why

A header + dashboard interaction pass covering four requested improvements. Everything stays within Quiet Instrumentality (hairlines, muted accents, 180ms motion, relative time, no spinners/decoration).

### 1. Keyboard shortcuts
DESIGN_SPEC calls for keyboard-first, but only scattered Escape handling existed. Adds a core layer via a reusable `useKeyboardShortcuts` hook:

| Key | Action |
|-----|--------|
| `/` | Focus search |
| `e` | Edit dashboard |
| `⌘`/`Ctrl` + `S` | Save (when editing + dirty) |
| `Esc` | Exit edit · close overlay |
| `?` | Toggle a quiet shortcuts cheat-sheet (`ShortcutsOverlay`) |

The hook stays silent while typing in inputs/textareas/contenteditable so normal text entry isn't hijacked. A subtle `/` keycap hint sits in the search field. `startEditing`/`resetEditing`/`saveDashboard` are now `useCallback`-stable.

### 2. Notifications tray (Steam-style)
A bell left of the avatar with an unread badge and a quiet dropdown. Events are derived **client-side** from live server status (online↔offline transitions) — no new backend. The first observation seeds a silent baseline so a reload doesn't replay current state as events. Only a numeric `last-seen` is persisted to localStorage (never notification text, which can name servers). Opening marks read. Empty state: "Nothing new."

### 3. Avatar dropdown cleanup
Removed dead placeholders (View profile, Dashboard, Personal/Workspace settings `[Soon]`, Theme, Server monitor, About, account-label footer). Kept only working items: server summary, identity (name + account), search-provider switcher, Send feedback, Log out. Every entry now does something.

### 4. Edit-mode affordance
An empty single-module root (after deleting Weather/Calendar/Markets) now shows an inline dashed "Add <module>" button in the body instead of just a floating control above an empty section.

## Test plan
- [x] `npx tsc --noEmit`, `npm run lint`, `npm run test:unit` (13/13), `npm run build` all pass
- [x] Browser: `e` enters edit, `Esc` exits; notifications dropdown opens with "Nothing new."; avatar menu shows only working entries
- [ ] `/` focuses search and `?` opens the cheat-sheet (verified the binding mechanism via `e`/`Esc`; `/` + `?` not auto-tested because the automation harness doesn't dispatch those `keydown`s reliably)
- [ ] Notification fires on a real server going offline→online (couldn't stage a live transition this session)

## Notes for reviewer
- Notifications v1 sources only server up/down. Module-fetch-error events would need lifting per-module data state out of `TreeModule` — deferred intentionally.
- No persisted state contains secrets or user-named content (only a numeric timestamp).

🤖 Generated with [Claude Code](https://claude.com/claude-code)